### PR TITLE
Fix mistake with write()

### DIFF
--- a/scripts/cocaine-tool.py
+++ b/scripts/cocaine-tool.py
@@ -41,6 +41,7 @@ DEFAULT_PORT=10053
 def sync_decorator(func):
     def wrapper(*args, **kwargs):
         try:
+            res = ""
             info = func(*args, **kwargs)
             res = info.next()
             info.next()


### PR DESCRIPTION
Syncwrapper around service methods returns res after StopIteration
exception. Returning value is evaluated, as soon as first chunk comes,
but in write() method of storage returns choke only and wrapper raises
StopIteration. So I return variable before its assigment.
Fix it with default res value - ""
