### PR TITLE
Checking pointer before dereferencing

### DIFF
--- a/include/cocaine/rpc/decoder.hpp
+++ b/include/cocaine/rpc/decoder.hpp
@@ -38,7 +38,9 @@ struct decoder {
     }
 
    ~decoder() {
-        unbind();
+       if (m_stream) {
+           unbind();
+       }
     }
 
     void


### PR DESCRIPTION
Decoder has default constructor that makes empty m_stream, but ~decoder dereferences it. So ~decoder must first check it!
