### PR TITLE
Replace text oriented stream operator << with binary safe method write

### DIFF
--- a/src/storages/files.cpp
+++ b/src/storages/files.cpp
@@ -133,7 +133,7 @@ files_t::write(const std::string& collection, const std::string& key, const std:
         }
     }
 
-    stream << blob;
+    stream.write(blob.c_str(), blob.size());
     stream.close();
 }
 


### PR DESCRIPTION
 fixes bug of libc++ under MacOS X 10.7
