### PR TITLE
A more reasonable default value of grow threshold.

### DIFF
--- a/src/profile.cpp
+++ b/src/profile.cpp
@@ -37,7 +37,7 @@ profile_t::profile_t(context_t& context, const std::string& name_):
     pool_limit          = get("pool-limit", static_cast<Json::UInt>(defaults::pool_limit)).asUInt();
     queue_limit         = get("queue-limit", static_cast<Json::UInt>(defaults::queue_limit)).asUInt();
 
-    unsigned long default_threshold = std::max(1UL, queue_limit / pool_limit * concurrency);
+    unsigned long default_threshold = std::max(1UL, queue_limit / pool_limit / 2);
 
     grow_threshold      = get("grow-threshold", static_cast<Json::UInt>(default_threshold)).asUInt();
 


### PR DESCRIPTION
Default value queue_limit / pool_limit \* concurrency may be more than queue_limit. It leads to the fact that available workers will not be started when they are needed. I have changed the value to queue_limit / pool_limit / 2. This value makes the runtime to run all available workers when the queue is half full.
