### PR TITLE
Check if a pointer is not null before dereferencing it.

### DIFF
--- a/include/cocaine/rpc/channel.hpp
+++ b/include/cocaine/rpc/channel.hpp
@@ -77,7 +77,11 @@ public:
 
     size_t
     footprint() const {
-        return rd->stream()->footprint() + wr->stream()->footprint();
+        if (rd->stream() && wr->stream()) {
+            return rd->stream()->footprint() + wr->stream()->footprint();
+        } else {
+            return 0;
+        }
     }
 
     std::unique_ptr<decoder<readable_stream<Socket>>> rd;


### PR DESCRIPTION
Channel may not have attached stream. In this case footprint equals 0.
