### PR TITLE
Add libcgroup to build dependencies in *.spec.

### DIFF
--- a/cocaine-bf.spec
+++ b/cocaine-bf.spec
@@ -13,7 +13,7 @@ BuildRoot:	%{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 BuildRequires: gcc44 gcc44-c++
 %endif
 BuildRequires: boost-python, boost-devel, boost-iostreams, boost-thread, boost-python, boost-system
-BuildRequires: libev-devel, openssl-devel, libtool-ltdl-devel, libuuid-devel
+BuildRequires: libev-devel, openssl-devel, libtool-ltdl-devel, libuuid-devel, libcgroup-devel
 BuildRequires: cmake28, msgpack-devel, libarchive-devel, binutils-devel
 
 Obsoletes: srw


### PR DESCRIPTION
Since CGroups isolation plugin was merged into Core, Core does not compile.
