### PR TITLE
Added support for Fedora 19, 20

### DIFF
--- a/cocaine-bf.spec
+++ b/cocaine-bf.spec
@@ -1,17 +1,28 @@
 Summary:	Cocaine - Core Libraries
 Name:		libcocaine-core2
 Version:	0.11.2.0
-Release:	1%{?dist}
+Release:	2%{?dist}
+%define cocaine_runtime_name      cocaine-runtime
+
 
 License:	GPLv2+
 Group:		System Environment/Libraries
 URL:		http://www.github.com/cocaine
 Source0:	%{name}-%{version}.tar.bz2
+Source1:	%{cocaine_runtime_name}.service
+Source2:        %{cocaine_runtime_name}.tmpfiles
+Patch0:		libcocaine-boost-mt.patch
 BuildRoot:	%{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
+
 %if 0%{?rhel} < 6
-BuildRequires: gcc44 gcc44-c++
+  %if 0%{?fedora} >= 19
+    %define distro_buildreq       gcc gcc-c++
+  %else
+    %define distro_buildreq       gcc44 gcc44-c++
+  %endif
 %endif
+BuildRequires:  %{distro_buildreq}
 BuildRequires: boost-python, boost-devel, boost-iostreams, boost-thread, boost-python, boost-system
 BuildRequires: libev-devel, openssl-devel, libtool-ltdl-devel, libuuid-devel, libcgroup-devel
 BuildRequires: cmake28, msgpack-devel, libarchive-devel, binutils-devel
@@ -29,21 +40,30 @@ Requires: %{name} = %{version}-%{release}
 %description devel
 Cocaine development headers package.
 
-%package -n cocaine-runtime
+%package -n %{cocaine_runtime_name}
 Summary:	Cocaine - Runtime
 Group:		Development/Libraries
 
-%description -n cocaine-runtime
+%description -n %{cocaine_runtime_name}
 Cocaine runtime components package.
 
 %prep
 %setup -q
+%if 0%{?fedora} >= 19
+%patch0 -p1
+%endif
 
 %build
 %if 0%{?rhel} < 6
+%if 0%{?fedora} >= 19
+export CC=gcc
+export CXX=g++
+CXXFLAGS="-pthread -I/usr/include/boost141" LDFLAGS="-L/usr/lib64/boost141" %{cmake28} -DBoost_DIR=/usr/lib64/boost141 -DBOOST_INCLUDEDIR=/usr/include/boost141 -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DCOCAINE_LIBDIR=%{_libdir} .
+%else
 export CC=gcc44
 export CXX=g++44
 CXXFLAGS="-pthread -I/usr/include/boost141" LDFLAGS="-L/usr/lib64/boost141" %{cmake28} -DBoost_DIR=/usr/lib64/boost141 -DBOOST_INCLUDEDIR=/usr/include/boost141 -DCMAKE_CXX_COMPILER=g++44 -DCMAKE_C_COMPILER=gcc44 -DCOCAINE_LIBDIR=%{_libdir} .
+%endif
 %else
 %{cmake28} -DCOCAINE_LIBDIR=%{_libdir} .
 %endif
@@ -58,13 +78,35 @@ make install DESTDIR=%{buildroot}
 rm -f %{buildroot}%{_libdir}/*.a
 rm -f %{buildroot}%{_libdir}/*.la
 
+%if 0%{?fedora} >= 19
+# Install systemd unit
+install -p -D -m 644 %{SOURCE1} %{buildroot}/%{_unitdir}/%{cocaine_runtime_name}.service
+%else
 install -dD %{buildroot}%{_sysconfdir}/init.d/
-install -m 755 debian/cocaine-runtime.init %{buildroot}%{_sysconfdir}/init.d/cocaine-runtime
+install -m 755 debian/cocaine-runtime.init %{buildroot}%{_sysconfdir}/init.d/%{cocaine_runtime_name}
+%{_sysconfdir}/init.d/*
+%endif
+
+install -d -m 755 %{buildroot}%{_localstatedir}/run/cocaine
+
+%if 0%{?fedora} >= 19
+mkdir -p %{buildroot}%{_tmpfilesdir}
+# Install systemd tmpfiles config
+install -p -D -m 644 %{SOURCE2} %{buildroot}%{_tmpfilesdir}/%{cocaine_runtime_name}.conf
+%endif
 
 install -d %{buildroot}%{_sysconfdir}/cocaine
 install -m644 debian/cocaine-runtime.conf %{buildroot}%{_sysconfdir}/cocaine/cocaine-default.conf
 
 %post -p /sbin/ldconfig
+
+%post -n %{cocaine_runtime_name}
+%if 0%{?fedora} >= 19
+if [ $1 -eq 1 ] ; then
+    /bin/systemctl daemon-reload >/dev/null 2>&1 || :
+fi
+%endif
+
 %postun -p /sbin/ldconfig
 
 %clean
@@ -81,8 +123,20 @@ rm -rf %{buildroot}
 %{_libdir}/libcocaine-core.so
 %{_libdir}/libjson.so
 
-%files -n cocaine-runtime
+%files -n %{cocaine_runtime_name}
 %defattr(-,root,root,-)
 %{_bindir}/cocaine-runtime
+
+%if 0%{?fedora} >= 19
+%{_tmpfilesdir}/%{cocaine_runtime_name}.conf
+%{_unitdir}/%{cocaine_runtime_name}.service
+%attr(0775,root,zabbix) %dir %{_localstatedir}/run/cocaine
+%else
 %{_sysconfdir}/init.d/*
+%endif
 %{_sysconfdir}/cocaine/cocaine-default.conf
+
+%changelog
+* Fri Jan 17 2014 Oleg Cherniy <oleg.cherniy@gmail.com> 0.11.2.0-2
+- Added support for Fedora 19, 20
+

--- a/fedora/cocaine-runtime.service
+++ b/fedora/cocaine-runtime.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Cocaine runtime components
+After=syslog.target network.target
+
+[Service]
+PIDFile=/var/run/cocaine-runtime.pid
+ExecStart=/usr/bin/cocaine-runtime -c /etc/cocaine/cocaine-default.conf
+User=root
+Group=root
+
+[Install]
+WantedBy=multi-user.target

--- a/fedora/cocaine-runtime.tmpfiles
+++ b/fedora/cocaine-runtime.tmpfiles
@@ -1,0 +1,2 @@
+# cocaine-runtime runtime directory
+d /var/run/cocaine 0755 root root -

--- a/fedora/libcocaine-boost-mt.patch
+++ b/fedora/libcocaine-boost-mt.patch
@@ -1,0 +1,23 @@
+diff -bur libcocaine-core2-0.11.2.0.orig/CMakeLists.txt libcocaine-core2-0.11.2.0/CMakeLists.txt
+--- libcocaine-core2-0.11.2.0.orig/CMakeLists.txt	2013-12-18 16:43:36.000000000 +0200
++++ libcocaine-core2-0.11.2.0/CMakeLists.txt	2014-01-14 00:44:31.309000000 +0200
+@@ -120,8 +120,8 @@
+ 
+ TARGET_LINK_LIBRARIES(cocaine-core
+     archive
+-    boost_system-mt
+-    boost_filesystem-mt
++    boost_system
++    boost_filesystem
+     ${LIBCGROUP_LIBRARY}
+     ${LIBCRYPTO_LIBRARY}
+     ev
+@@ -139,7 +139,7 @@
+ 
+ TARGET_LINK_LIBRARIES(cocaine-runtime
+     ${LIBBFD_LIBRARY}
+-    boost_program_options-mt
++    boost_program_options
+     cocaine-core)
+ 
+ SET_TARGET_PROPERTIES(cocaine-core cocaine-runtime PROPERTIES


### PR DESCRIPTION
Собрал все пакеты для Fedora 20, проверял на Fedora 19. Совместимость со сборкой для RedHat не проверял, по идее ничего Вашего не трогал. Логику сборки разграничил If-ами.
Все пакеты по зависимостям для Fedora есть тут:
http://linux.ria.ua/SRPMS/fedora_repository/20/SRPMS/

После установки пакета можно запускать с конфигом "по-умолчанию"
/bin/systemctl start  cocaine-runtime.service либо по-старинке
/sbin/service cocaine-runtime start

PS: Тут http://habrahabr.ru/company/yandex/blog/209324/ написали: "будем очень рады пул реквестам", вот вам пул реквест :)
