### PR TITLE
Fixed warning about unused private field.

### DIFF
--- a/include/cocaine/detail/client.hpp
+++ b/include/cocaine/detail/client.hpp
@@ -126,8 +126,7 @@ class service_resolver_t {
 public:
     typedef io::tcp::endpoint endpoint_type;
 
-    service_resolver_t(context_t&,
-                       io::reactor_t& reactor,
+    service_resolver_t(io::reactor_t& reactor,
                        const std::vector<endpoint_type>& locator,
                        const std::string& service):
         m_reactor(reactor),

--- a/include/cocaine/detail/raft/client.hpp
+++ b/include/cocaine/detail/raft/client.hpp
@@ -62,7 +62,6 @@ public:
         // Boost optional is needed to provide default value dependent on the context.
         boost::optional<float> request_timeout = boost::none
     ):
-        m_context(context),
         m_reactor(reactor),
         m_logger(new logging::log_t(context, "raft_client/" + name)),
         m_timeout_timer(reactor.native()),
@@ -271,7 +270,6 @@ private:
                               endpoint.second);
 
             m_resolver = std::make_shared<service_resolver_t>(
-                m_context,
                 m_reactor,
                 io::resolver<io::tcp>::query(endpoint.first, endpoint.second),
                 m_name
@@ -323,8 +321,6 @@ private:
     }
 
 private:
-    context_t &m_context;
-
     io::reactor_t &m_reactor;
 
     const std::unique_ptr<logging::log_t> m_logger;

--- a/include/cocaine/detail/raft/remote.hpp
+++ b/include/cocaine/detail/raft/remote.hpp
@@ -494,7 +494,6 @@ private:
             COCAINE_LOG_DEBUG(m_logger, "Client is not connected. Connecting...");
 
             m_resolver = std::make_shared<service_resolver_t>(
-                m_actor.context(),
                 m_actor.reactor(),
                 io::resolver<io::tcp>::query(m_id.first, m_id.second),
                 m_actor.context().config.raft.node_service_name


### PR DESCRIPTION
Because we treat warnings as errors it results in compile error.
