### PR TITLE
Fixed building on some systems.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -120,8 +120,7 @@ ADD_LIBRARY(cocaine-core SHARED
 
 TARGET_LINK_LIBRARIES(cocaine-core
     archive
-    boost_system-mt
-    boost_filesystem-mt
+    ${Boost_LIBRARIES}
     ${LIBCGROUP_LIBRARY}
     ${LIBCRYPTO_LIBRARY}
     ev


### PR DESCRIPTION
Now ${Boost_LIBRARIES} variable is used instead of particular Boost library names. For example, these libraries have some different names on Ubuntu Trusty and Fedora.
Also you may want to cherry-pick this commit to the master.
