### PR TITLE
Fixed building on some systems again.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -138,7 +138,7 @@ ADD_EXECUTABLE(cocaine-runtime
 
 TARGET_LINK_LIBRARIES(cocaine-runtime
     ${LIBBFD_LIBRARY}
-    boost_program_options-mt
+    ${Boost_LIBRARIES}
     cocaine-core)
 
 SET_TARGET_PROPERTIES(cocaine-core cocaine-runtime PROPERTIES


### PR DESCRIPTION
Cocaine Runtime also links with some boost libraries. I forgot to fix it in the previous commit.
