### PR TITLE
Remove boost-python from BuildRequires

### DIFF
--- a/cocaine-bf.spec
+++ b/cocaine-bf.spec
@@ -16,7 +16,7 @@ BuildRoot:	%{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 BuildRequires: gcc44 gcc44-c++
 %endif
 
-BuildRequires: boost-python, boost-devel, boost-iostreams, boost-thread, boost-python, boost-system
+BuildRequires: boost-devel, boost-iostreams, boost-thread, boost-system
 BuildRequires: libev-devel, openssl-devel, libtool-ltdl-devel, libuuid-devel, libcgroup-devel
 BuildRequires: msgpack-devel, libarchive-devel, binutils-devel
 


### PR DESCRIPTION
Could you cherry-pick this commit and c3811556850b118c297c78ec339a2a16749208ed into v0.11 to fix rpm package building, please?
