### PR TITLE
Message with verbosity 0 

### DIFF
--- a/src/context.cpp
+++ b/src/context.cpp
@@ -466,7 +466,7 @@ map_severity(blackhole::aux::attachable_ostringstream& stream, const logging::pr
 
     auto value = static_cast<level_type>(level);
 
-    if(value < static_cast<level_type>(sizeof(describe) / sizeof(describe[0]))) {
+    if(value < static_cast<level_type>(sizeof(describe) / sizeof(describe[0])) && value > 0) {
         stream << describe[value];
     } else {
         stream << value;


### PR DESCRIPTION
Message with verbosity 0 leads cocaine-runtime to segfault as nullptr is sent to a stream.

```
* thread #2: tid = 0x10b25, 0x00007fff8ca05732 libsystem_c.dylib`strlen + 18, stop reason = EXC_BAD_ACCESS (code=1, address=0x0)
  * frame #0: 0x00007fff8ca05732 libsystem_c.dylib`strlen + 18
    frame #1: 0x00000001002ba7f4 libcocaine-core.2.dylib`blackhole::aux::attachable_basic_ostringstream<char, std::__1::char_traits<char>, std::__1::allocator<char> >::operator<<(char const*) + 52
    frame #2: 0x00000001001df2ce libcocaine-core.2.dylib`(anonymous namespace)::map_severity(blackhole::aux::attachable_basic_ostringstream<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, cocaine::logging::priorities const&) + 62
    frame #3: 0x000000010023a90c libcocaine-core.2.dylib`std::__1::__function::__func<void (*)(blackhole::aux::attachable_basic_ostringstream<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, cocaine::logging::priorities const&), std::__1::allocator<void (*)(blackhole::aux::attachable_basic_ostringstream<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, cocaine::logging::priorities const&)>, void (blackhole::aux::attachable_basic_ostringstream<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, cocaine::logging::priorities const&)>::operator()(blackhole::aux::attachable_basic_ostringstream<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, cocaine::logging::priorities const&) + 124
    frame #4: 0x000000010023c904 libcocaine-core.2.dylib`std::__1::function<void (blackhole::aux::attachable_basic_ostringstream<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, cocaine::logging::priorities const&)>::operator()(blackhole::aux::attachable_basic_ostringstream<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, cocaine::logging::priorities const&) const + 196
    frame #5: 0x000000010023c836 libcocaine-core.2.dylib`blackhole::mapping::extracter<cocaine::logging::priorities>::operator()(blackhole::aux::attachable_basic_ostringstream<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, boost::variant<unsigned int, int, unsigned long long, long long, double, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, timeval, boost::detail::variant::void_, boost::detail::variant::void_, boost::detail::variant::void_, boost::detail::variant::void_, boost::detail::variant::void_, boost::detail::variant::void_, boost::detail::variant::void_, boost::detail::variant::void_, boost::detail::variant::void_, boost::detail::variant::void_, boost::detail::variant::void_, boost::detail::variant::void_, boost::detail::variant::void_> const&) const + 70
    frame #6: 0x000000010023c74c libcocaine-core.2.dylib`std::__1::__function::__func<blackhole::mapping::extracter<cocaine::logging::priorities>, std::__1::allocator<blackhole::mapping::extracter<cocaine::logging::priorities> >, void (blackhole::aux::attachable_basic_ostringstream<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, boost::variant<unsigned int, int, unsigned long long, long long, double, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, timeval, boost::detail::variant::void_, boost::detail::variant::void_, boost::detail::variant::void_, boost::detail::variant::void_, boost::detail::variant::void_, boost::detail::variant::void_, boost::detail::variant::void_, boost::detail::variant::void_, boost::detail::variant::void_, boost::detail::variant::void_, boost::detail::variant::void_, boost::detail::variant::void_, boost::detail::variant::void_> const&)>::operator()(blackhole::aux::attachable_basic_ostringstream<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, boost::variant<unsigned int, int, unsigned long long, long long, double, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, timeval, boost::detail::variant::void_, boost::detail::variant::void_, boost::detail::variant::void_, boost::detail::variant::void_, boost::detail::variant::void_, boost::detail::variant::void_, boost::detail::variant::void_, boost::detail::variant::void_, boost::detail::variant::void_, boost::detail::variant::void_, boost::detail::variant::void_, boost::detail::variant::void_, boost::detail::variant::void_> const&) + 124
```
