### PR TITLE
[Common] Platform specific stuff.

### DIFF
--- a/include/cocaine/detail/service/node/event.hpp
+++ b/include/cocaine/detail/service/node/event.hpp
@@ -27,7 +27,7 @@ namespace cocaine { namespace api {
 
 struct policy_t {
     // TODO: Consider some environment-independent workaround.
-#if defined(__clang__) || defined(HAVE_GCC48)
+#ifdef COCAINE_HAS_FEATURE_STEADY_CLOCK
     typedef std::chrono::steady_clock clock_type;
 #else
     typedef std::chrono::monotonic_clock clock_type;

--- a/include/cocaine/detail/service/node/slave.hpp
+++ b/include/cocaine/detail/service/node/slave.hpp
@@ -75,7 +75,7 @@ class slave_t : public std::enable_shared_from_this<slave_t> {
     // Health.
     states m_state;
 
-#if defined(__clang__) || defined(HAVE_GCC48)
+#ifdef COCAINE_HAS_FEATURE_STEADY_CLOCK
     const std::chrono::steady_clock::time_point m_birthstamp;
 #else
     const std::chrono::monotonic_clock::time_point m_birthstamp;

--- a/include/cocaine/platform.hpp
+++ b/include/cocaine/platform.hpp
@@ -35,4 +35,12 @@
     #endif
 #endif
 
+#if defined(__clang__) || defined(HAVE_GCC47)
+    #define COCAINE_HAS_FEATURE_UNDERLYING_TYPE
+#endif
+
+#if defined(__clang__) || defined(HAVE_GCC48)
+    #define COCAINE_HAS_FEATURE_STEADY_CLOCK
+#endif
+
 #endif

--- a/include/cocaine/traits/enum.hpp
+++ b/include/cocaine/traits/enum.hpp
@@ -21,6 +21,7 @@
 #ifndef COCAINE_ENUM_SERIALIZATION_TRAITS_HPP
 #define COCAINE_ENUM_SERIALIZATION_TRAITS_HPP
 
+#include "cocaine/platform.hpp"
 #include "cocaine/traits.hpp"
 
 #include <type_traits>
@@ -36,7 +37,7 @@ struct type_traits<
     typename std::enable_if<std::is_enum<T>::value>::type
 >
 {
-#if defined(__clang__) || defined(GCC47)
+#ifdef COCAINE_HAS_FEATURE_UNDERLYING_TYPE
     typedef typename std::underlying_type<T>::type base_type;
 #else
     typedef int base_type;

--- a/src/service/node/slave.cpp
+++ b/src/service/node/slave.cpp
@@ -86,7 +86,7 @@ slave_t::slave_t(const std::string& id,
     m_rebalance(rebalance),
     m_suicide(suicide),
     m_state(states::unknown),
-#if defined(__clang__) || defined(HAVE_GCC48)
+#ifdef COCAINE_HAS_FEATURE_STEADY_CLOCK
     m_birthstamp(std::chrono::steady_clock::now()),
 #else
     m_birthstamp(std::chrono::monotonic_clock::now()),
@@ -337,7 +337,7 @@ slave_t::on_ping() {
     );
 
     if(m_state == states::unknown) {
-#if defined(__clang__) || defined(HAVE_GCC48)
+#ifdef COCAINE_HAS_FEATURE_STEADY_CLOCK
         auto now = std::chrono::steady_clock::now();
 #else
         auto now = std::chrono::monotonic_clock::now();


### PR DESCRIPTION
Minor cleanup to get rid of that annoying `if defined(__clang__) || defined(HAVE_GCCXX)`.
