### PR TITLE
[Detail] Mangle macro internal variables.

### DIFF
--- a/include/cocaine/logging.hpp
+++ b/include/cocaine/logging.hpp
@@ -46,8 +46,8 @@ demangle() -> std::string {
 }} // namespace cocaine::logging
 
 #define COCAINE_LOG(_log_, _level_, ...) \
-    if(auto record = (_log_)->open_record(_level_)) \
-        ::blackhole::aux::logger::make_pusher(*(_log_), record, __VA_ARGS__)
+    if(auto _record_ = (_log_)->open_record(_level_)) \
+        ::blackhole::aux::logger::make_pusher(*(_log_), _record_, __VA_ARGS__)
 
 #define COCAINE_LOG_DEBUG(_log_, ...) \
     COCAINE_LOG(_log_, ::cocaine::logging::debug, __VA_ARGS__)


### PR DESCRIPTION
It is needed to avoid possible conflicts. For example, I've just fixed funny bug in Elliptics plugin, which compiled, but worked randomly.

``` cpp
void log_adapter_impl_t::handle(const blackhole::record_t &record)
{
    dnet_log_level level = record.extract<dnet_log_level>(blackhole::keyword::severity<dnet_log_level>().name());
    auto cocaine_level = convert_verbosity(level);
    COCAINE_LOG(m_log, cocaine_level, "%s", m_formatter.format(record));
}
```

After text substitution it resulted in the following code, where you can notice highly unexpected `m_formatter.format(record)` line, which uses just created `record` variable instead of provided one.

``` cpp
void log_adapter_impl_t::handle(const blackhole::record_t &record)
{
    dnet_log_level level = record.extract<dnet_log_level>(blackhole::keyword::severity<dnet_log_level>().name());
    auto cocaine_level = convert_verbosity(level);
    if(auto record = (m_log)->open_record(cocaine_level))
        ::blackhole::aux::logger::make_pusher(*(m_log), record, "%s", m_formatter.format(record));
}
```

This fix should help to avoid these cases.
