### PR TITLE
[API] Deduce socket type via its protocol.

### DIFF
--- a/include/cocaine/rpc/asio/channel.hpp
+++ b/include/cocaine/rpc/asio/channel.hpp
@@ -32,7 +32,7 @@ namespace cocaine { namespace io {
 template<class Protocol>
 struct channel {
     typedef Protocol protocol_type;
-    typedef asio::basic_stream_socket<protocol_type> socket_type;
+    typedef typename protocol_type::socket socket_type;
 
     explicit
     channel(std::unique_ptr<socket_type> socket_):

--- a/include/cocaine/rpc/asio/readable_stream.hpp
+++ b/include/cocaine/rpc/asio/readable_stream.hpp
@@ -42,7 +42,7 @@ class readable_stream:
 
     static const size_t kInitialBufferSize = 65536;
 
-    typedef asio::basic_stream_socket<Protocol> channel_type;
+    typedef typename Protocol::socket channel_type;
 
     typedef Decoder decoder_type;
     typedef typename decoder_type::message_type message_type;

--- a/include/cocaine/rpc/asio/writable_stream.hpp
+++ b/include/cocaine/rpc/asio/writable_stream.hpp
@@ -40,7 +40,7 @@ class writable_stream:
 {
     COCAINE_DECLARE_NONCOPYABLE(writable_stream)
 
-    typedef asio::basic_stream_socket<Protocol> channel_type;
+    typedef typename Protocol::socket channel_type;
 
     typedef Encoder encoder_type;
     typedef typename encoder_type::message_type message_type;


### PR DESCRIPTION
This change allows to work with Cocaine channels in conjunction with either pure asio or boost::asio.