### PR TITLE
[Logging] Blackhole with versioned namespaces.

### DIFF
--- a/include/cocaine/detail/bootstrap/logging.hpp
+++ b/include/cocaine/detail/bootstrap/logging.hpp
@@ -29,7 +29,9 @@
 
 #include <blackhole/repository/config/parser.hpp>
 
-namespace blackhole { namespace repository { namespace config {
+BLACKHOLE_BEG_NS
+
+namespace repository { namespace config {
 
 template<>
 struct transformer_t<cocaine::dynamic_t> {
@@ -40,11 +42,15 @@ struct transformer_t<cocaine::dynamic_t> {
     transform(const value_type& value);
 };
 
-}}} // namespace blackhole::repository::config
+}} // namespace repository::config
+
+BLACKHOLE_END_NS
 
 #include <blackhole/frontend/syslog.hpp>
 
-namespace blackhole { namespace sink {
+BLACKHOLE_BEG_NS
+
+namespace sink {
 
 template<>
 struct priority_traits<cocaine::logging::priorities> {
@@ -53,7 +59,9 @@ struct priority_traits<cocaine::logging::priorities> {
     map(cocaine::logging::priorities level);
 };
 
-}} // namespace blackhole::sink
+} // namespace sink
+
+BLACKHOLE_END_NS
 
 namespace cocaine { namespace logging {
 

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -22,7 +22,9 @@
 
 #include <cxxabi.h>
 
-namespace blackhole { namespace repository { namespace config {
+BLACKHOLE_BEG_NS
+
+namespace repository { namespace config {
 
 // Converter adapter specializations for dynamic value
 
@@ -59,9 +61,13 @@ transformer_t<cocaine::dynamic_t>::transform(const value_type& value) {
     return dynamic_t();
 }
 
-}}} // namespace blackhole::repository::config
+}} // namespace repository::config
 
-namespace blackhole { namespace sink {
+BLACKHOLE_END_NS
+
+BLACKHOLE_BEG_NS
+
+namespace sink {
 
 // Mapping trait that is called by Blackhole each time when syslog mapping is required
 
@@ -83,7 +89,9 @@ priority_traits<cocaine::logging::priorities>::map(cocaine::logging::priorities 
     return priority_t::debug;
 }
 
-}} // namespace blackhole::sink
+} // namespace sink
+
+BLACKHOLE_END_NS
 
 namespace cocaine { namespace logging {
 


### PR DESCRIPTION
After this commit, cocaine-core can be safely linked with multiple libraries, that are compiled with Blackhole version different from the Cocaine compiled one.

For example, Elliptics uses Blackhole v0.2 (much legacy, so ancient, wow <img src="http://cdn7.staztic.com/app/a/3560/3560202/doge-snake-1-l-124x124.png" height="30" width="30">) and produces the plugin, which is dependent from Cocaine, which uses Blackhole v0.5. Bad things can happen.

Internally Blackhole's versioned namespaces are inline, so this change shouldn't change anything in the codebase. Unfortunately, only clang allows to extend inline namespaces without specifying that namespace explicitly.