### PR TITLE
Deferred for custom slot

### DIFF
--- a/include/cocaine/rpc/queue.hpp
+++ b/include/cocaine/rpc/queue.hpp
@@ -92,7 +92,6 @@ template<class Tag, class Upstream>
 class message_queue {
     typedef Upstream upstream_type;
 
-private:
     typedef typename mpl::transform<
         typename messages<Tag>::type,
         typename mpl::lambda<aux::frozen<mpl::_1>>

--- a/include/cocaine/rpc/queue.hpp
+++ b/include/cocaine/rpc/queue.hpp
@@ -90,7 +90,6 @@ private:
 
 template<class Tag, class Upstream>
 class message_queue {
-public:
     typedef Upstream upstream_type;
 
 private:

--- a/include/cocaine/rpc/queue.hpp
+++ b/include/cocaine/rpc/queue.hpp
@@ -90,8 +90,10 @@ private:
 
 template<class Tag, class Upstream>
 class message_queue {
+public:
     typedef Upstream upstream_type;
 
+private:
     typedef typename mpl::transform<
         typename messages<Tag>::type,
         typename mpl::lambda<aux::frozen<mpl::_1>>

--- a/include/cocaine/rpc/slot/deferred.hpp
+++ b/include/cocaine/rpc/slot/deferred.hpp
@@ -128,8 +128,8 @@ struct deferred {
         return *this;
     }
 
-    template <class upstream_type>
-    void attach(upstream_type&& upstream) const {
+    template<class UpstreamType>
+    void attach(UpstreamType&& upstream) const {
         outbox->synchronize()->attach(std::move(upstream));
     }
 
@@ -163,8 +163,8 @@ struct deferred<void> {
         return *this;
     }
 
-    template <class upstream_type>
-    void attach(upstream_type&& upstream) {
+    template<class UpstreamType>
+    void attach(UpstreamType&& upstream) {
         outbox->synchronize()->attach(std::move(upstream));
     }
 

--- a/include/cocaine/rpc/slot/deferred.hpp
+++ b/include/cocaine/rpc/slot/deferred.hpp
@@ -129,7 +129,8 @@ struct deferred {
     }
 
     template<class UpstreamType>
-    void attach(UpstreamType&& upstream) const {
+    void
+    attach(UpstreamType&& upstream) const {
         outbox->synchronize()->attach(std::move(upstream));
     }
 
@@ -164,7 +165,8 @@ struct deferred<void> {
     }
 
     template<class UpstreamType>
-    void attach(UpstreamType&& upstream) {
+    void
+    attach(UpstreamType&& upstream) {
         outbox->synchronize()->attach(std::move(upstream));
     }
 

--- a/include/cocaine/rpc/slot/streamed.hpp
+++ b/include/cocaine/rpc/slot/streamed.hpp
@@ -60,6 +60,11 @@ struct streamed {
         return *this;
     }
 
+    template <class upstream_type>
+    void attach(upstream_type&& upstream) const {
+        outbox->synchronize()->attach(std::move(upstream));
+    }
+
 private:
     const std::shared_ptr<synchronized<queue_type>> outbox;
 };

--- a/include/cocaine/rpc/slot/streamed.hpp
+++ b/include/cocaine/rpc/slot/streamed.hpp
@@ -61,7 +61,8 @@ struct streamed {
     }
 
     template<class UpstreamType>
-    void attach(UpstreamType&& upstream) const {
+    void
+    attach(UpstreamType&& upstream) const {
         outbox->synchronize()->attach(std::move(upstream));
     }
 

--- a/include/cocaine/rpc/slot/streamed.hpp
+++ b/include/cocaine/rpc/slot/streamed.hpp
@@ -60,8 +60,8 @@ struct streamed {
         return *this;
     }
 
-    template <class upstream_type>
-    void attach(upstream_type&& upstream) const {
+    template<class UpstreamType>
+    void attach(UpstreamType&& upstream) const {
         outbox->synchronize()->attach(std::move(upstream));
     }
 

--- a/include/cocaine/tuple.hpp
+++ b/include/cocaine/tuple.hpp
@@ -66,6 +66,13 @@ struct invoke_impl<index_sequence<Indices...>> {
     template<class F, typename... Args>
     static inline
     typename result_of<F>::type
+    apply(F&& callable, std::tuple<Args...>&& args) {
+        return callable(std::get<Indices>(args)...);
+    }
+
+    template<class F, typename... Args>
+    static inline
+    typename result_of<F>::type
     apply(const F& callable, std::tuple<Args...>&& args) {
         return callable(std::get<Indices>(args)...);
     }
@@ -82,6 +89,15 @@ struct fold {
 };
 
 // Function invocation with arguments provided as a tuple
+
+template<class F, typename... Args>
+inline
+typename result_of<F>::type
+invoke(F&& callable, std::tuple<Args...>&& args) {
+    return aux::invoke_impl<
+        typename make_index_sequence<sizeof...(Args)>::type
+    >::apply(std::move(callable), std::move(args));
+}
 
 template<class F, typename... Args>
 inline


### PR DESCRIPTION
Deffered is quite usefull even for custom protocol transitions. This patch allows defferred and streamed to be used in custom slots.
Also some const callables such as std::mem_fn can call only underlying const methods. So in general we might want to pass reference instead of const reference to tuple::invoke. This patch only allows passing rvalue references additionally to lvalue const references to be compatible with old behaviour.