### PR TITLE
[App] Don't throw moved ptr

### DIFF
--- a/src/service/node/app.cpp
+++ b/src/service/node/app.cpp
@@ -139,7 +139,7 @@ private:
         virtual
         void
         write(const char* chunk, size_t size) {
-            upstream.send<protocol::chunk>(literal_t { chunk, size });
+            upstream = upstream.send<protocol::chunk>(literal_t { chunk, size });
         }
 
         virtual


### PR DESCRIPTION
```upstream.send<protocol::chunk>``` returns moved pointer and we don't update the current upstream with this pointer, so next *write*, *close*, *error* will lead to EXC_BAD_ACCESS
