### PR TITLE
Fix --locator arg in slave

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+cocaine-core (0.12.0.2) unstable; urgency=low
+
+  * Fix --locator arg for a slave
+
+ -- Anton Tiurin <noxiouz@yandex.ru>  Wed, 18 Mar 2015 13:50:19 +0300
+
 cocaine-core (0.12.0.1) unstable; urgency=low
 
   * Release 0.12.0.1.

--- a/src/service/node/slave.cpp
+++ b/src/service/node/slave.cpp
@@ -182,7 +182,7 @@ slave_t::activate() {
     args["--uuid"]     = m_id;
     args["--app"]      = m_manifest.name;
     args["--endpoint"] = m_manifest.endpoint;
-    args["--locator"]  = cocaine::format("localhost:%d", locator.endpoints().front().port());
+    args["--locator"]  = cocaine::format("%s:%d", m_context.config.network.hostname, locator.endpoints().front().port());
 
     // Spawn a worker instance and start reading standard outputs of it.
     try {


### PR DESCRIPTION
Right now it's set to localhost:port by mistake. So an isolated worker can't resolve locator service.
Is it better to pass a comma-separated list of endpoints here like in resolving of a service? 