### PR TITLE
[RPC] Renamed graph types.

### DIFF
--- a/include/cocaine/idl/locator.hpp
+++ b/include/cocaine/idl/locator.hpp
@@ -60,7 +60,7 @@ struct resolve {
         unsigned int,
      /* A mapping between slot id numbers, message names and state transitions for both the message
         dispatch and upstream types to use in dynamic languages like Python, Ruby or JavaScript. */
-        graph_basis_t
+        graph_root_t
     >::tag upstream_type;
 };
 

--- a/include/cocaine/rpc/dispatch.hpp
+++ b/include/cocaine/rpc/dispatch.hpp
@@ -81,7 +81,7 @@ public:
 
     virtual
     auto
-    graph() const -> const graph_basis_t& = 0;
+    root() const -> const graph_root_t& = 0;
 
     auto
     name() const -> std::string;
@@ -99,7 +99,7 @@ template<class Tag>
 class dispatch:
     public io::basic_dispatch_t
 {
-    static const io::graph_basis_t kGraph;
+    static const io::graph_root_t kGraph;
 
     // Slot construction
 
@@ -157,7 +157,7 @@ public:
 
     virtual
     auto
-    graph() const -> const io::graph_basis_t& {
+    root() const -> const io::graph_root_t& {
         return kGraph;
     }
 
@@ -174,7 +174,7 @@ private:
 };
 
 template<class Tag>
-const io::graph_basis_t dispatch<Tag>::kGraph = io::traverse<Tag>().get();
+const io::graph_root_t dispatch<Tag>::kGraph = io::traverse<Tag>().get();
 
 namespace aux {
 

--- a/include/cocaine/rpc/graph.hpp
+++ b/include/cocaine/rpc/graph.hpp
@@ -29,28 +29,28 @@
 
 namespace cocaine { namespace io {
 
-struct graph_point_t;
+struct graph_node_t;
 
 namespace aux {
 
-// Protocol transitions are described by an optional<graph_point_t>. Transition could be a new graph
+// Protocol transitions are described by an optional<graph_node_t>. Transition could be a new graph
 // point, an empty graph point (terminal message) or none, which means recurrent transition.
 
 typedef std::map<
     int,
-    std::tuple<std::string, boost::optional<graph_point_t>>
+    std::tuple<std::string, boost::optional<graph_node_t>>
 > recursion_base_t;
 
 } // namespace aux
 
-struct graph_point_t: public aux::recursion_base_t {
+struct graph_node_t: public aux::recursion_base_t {
     typedef aux::recursion_base_t base_type;
 };
 
 typedef std::map<
     int,
-    std::tuple<std::string, boost::optional<graph_point_t>, boost::optional<graph_point_t>>
-> graph_basis_t;
+    std::tuple<std::string, boost::optional<graph_node_t>, boost::optional<graph_node_t>>
+> graph_root_t;
 
 }} // namespace cocaine::io
 

--- a/include/cocaine/rpc/traversal.hpp
+++ b/include/cocaine/rpc/traversal.hpp
@@ -31,7 +31,7 @@
 
 namespace cocaine { namespace io {
 
-template<class Tag, class Vertex = graph_basis_t>
+template<class Tag, class Vertex = graph_root_t>
 auto
 traverse() -> boost::optional<Vertex>;
 
@@ -46,12 +46,12 @@ struct traverse_impl {
 
     static inline
     void
-    apply(graph_basis_t& vertex) {
+    apply(graph_root_t& vertex) {
         vertex[traits_type::id] = std::make_tuple(event_type::alias(),
             std::is_same<typename traits_type::dispatch_type, typename event_type::tag>::value
               ? boost::none
-              : traverse<typename traits_type::dispatch_type, graph_point_t>(),
-            traverse<typename traits_type::upstream_type, graph_point_t>()
+              : traverse<typename traits_type::dispatch_type, graph_node_t>(),
+            traverse<typename traits_type::upstream_type, graph_node_t>()
         );
 
         traverse_impl<typename mpl::next<It>::type, End>::apply(vertex);
@@ -59,11 +59,11 @@ struct traverse_impl {
 
     static inline
     void
-    apply(graph_point_t& vertex) {
+    apply(graph_node_t& vertex) {
         vertex[traits_type::id] = std::make_tuple(event_type::alias(),
             std::is_same<typename traits_type::dispatch_type, typename event_type::tag>::value
               ? boost::none
-              : traverse<typename traits_type::dispatch_type, graph_point_t>()
+              : traverse<typename traits_type::dispatch_type, graph_node_t>()
         );
 
         traverse_impl<typename mpl::next<It>::type, End>::apply(vertex);
@@ -74,13 +74,13 @@ template<class End>
 struct traverse_impl<End, End> {
     static inline
     void
-    apply(graph_basis_t& COCAINE_UNUSED_(vertex)) {
+    apply(graph_root_t& COCAINE_UNUSED_(vertex)) {
         // Empty.
     }
 
     static inline
     void
-    apply(graph_point_t& COCAINE_UNUSED_(vertex)) {
+    apply(graph_node_t& COCAINE_UNUSED_(vertex)) {
         // Empty.
     }
 };

--- a/include/cocaine/traits/graph.hpp
+++ b/include/cocaine/traits/graph.hpp
@@ -29,18 +29,18 @@
 namespace cocaine { namespace io {
 
 template<>
-struct type_traits<graph_point_t> {
+struct type_traits<graph_node_t> {
     template<class Stream>
     static inline
     void
-    pack(msgpack::packer<Stream>& target, const graph_point_t& source) {
-        target << static_cast<const graph_point_t::base_type&>(source);
+    pack(msgpack::packer<Stream>& target, const graph_node_t& source) {
+        target << static_cast<const graph_node_t::base_type&>(source);
     }
 
     static inline
     void
-    unpack(const msgpack::object& source, graph_point_t& target) {
-        source >> static_cast<graph_point_t::base_type&>(target);
+    unpack(const msgpack::object& source, graph_node_t& target) {
+        source >> static_cast<graph_node_t::base_type&>(target);
     }
 };
 

--- a/src/api.cpp
+++ b/src/api.cpp
@@ -147,7 +147,7 @@ public:
 
 private:
     void
-    on_value(const std::vector<endpoint_type>& endpoints, int version, const io::graph_basis_t&) {
+    on_value(const std::vector<endpoint_type>& endpoints, int version, const io::graph_root_t&) {
         if(version != client.version()) {
             parent->m_asio.post(std::bind(handle, error::version_mismatch));
             return;

--- a/src/service/locator.cpp
+++ b/src/service/locator.cpp
@@ -404,7 +404,7 @@ locator_t::on_resolve(const std::string& name, const std::string& seed) const ->
         return results::resolve {
             provided.get().endpoints(),
             provided.get().prototype().version(),
-            provided.get().prototype().graph()
+            provided.get().prototype().root()
         };
     }
 
@@ -507,7 +507,7 @@ locator_t::on_service(const actor_t& actor) {
     const auto metadata = results::resolve {
         actor.endpoints(),
         actor.prototype().version(),
-        actor.prototype().graph()
+        actor.prototype().root()
     };
 
     const auto response = results::connect {


### PR DESCRIPTION
Instead of rather meaningless 'basis' and 'point', this commit implements a new
naming scheme for graph types - root and node. Which are common names for those
things.