### PR TITLE
[Bug Fix] Do not write on already deleted channel.

### DIFF
--- a/cocaine-bf.spec
+++ b/cocaine-bf.spec
@@ -1,8 +1,8 @@
 %define cocaine_runtime_name cocaine-runtime
 
 Summary:	Cocaine - Core Libraries
-Name:		libcocaine-core2
-Version:	0.12.0.1
+Name:		libcocaine-core3
+Version:	0.12.0.3
 Release:	1%{?dist}
 
 
@@ -125,6 +125,9 @@ rm -rf %{buildroot}
 %{_sysconfdir}/cocaine/cocaine-default.conf
 
 %changelog
+* Fri Mar 20 2015 Evgeny Safronov <division494@gmail.com> 0.12.0.3-1
+- Bug fix: do not read/write from/to already deleted channel.
+
 * Tue Oct 07 2014 Andrey Sibirev <me@kobology.ru> 0.12.0.1-1
 - Release 0.12.
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+cocaine-core (0.12.0.3) unstable; urgency=low
+
+  * Bug fix: do not read/write from/to already deleted channel.
+
+ -- Evgeny Safronov <division494@gmail.com>  Fri, 20 Mar 2015 19:00:25 +0300
+
 cocaine-core (0.12.0.2) unstable; urgency=low
 
   * Fix --locator arg for a slave

--- a/src/service/node/slave.cpp
+++ b/src/service/node/slave.cpp
@@ -329,6 +329,11 @@ slave_t::on_failure(const std::error_code& ec) {
 
 void
 slave_t::on_ping() {
+    if(m_state == states::inactive) {
+        // Slate is already inactive, do nothing.
+        return;
+    }
+
     COCAINE_LOG_DEBUG(m_log, "slave %s is resetting heartbeat timeout to %.02f seconds", m_id, m_profile.heartbeat_timeout);
 
     m_heartbeat_timer.expires_from_now(boost::posix_time::seconds(m_profile.heartbeat_timeout));

--- a/src/service/node/slave.cpp
+++ b/src/service/node/slave.cpp
@@ -333,7 +333,7 @@ slave_t::on_failure(const std::error_code& ec) {
 void
 slave_t::on_ping() {
     if(m_state == states::inactive) {
-        // Slate is already inactive, do nothing.
+        // Slave is already inactive, do nothing.
         return;
     }
 

--- a/src/service/node/slave.cpp
+++ b/src/service/node/slave.cpp
@@ -216,7 +216,10 @@ slave_t::on_read(const std::error_code& ec) {
         on_failure(ec);
     } else {
         on_message(m_message);
-        m_channel->reader->read(m_message, std::bind(&slave_t::on_read, shared_from_this(), ph::_1));
+
+        if(m_state != states::inactive) {
+            m_channel->reader->read(m_message, std::bind(&slave_t::on_read, shared_from_this(), ph::_1));
+        }
     }
 }
 


### PR DESCRIPTION
After a slave termination there can be pending heartbeat events. In this case we shouldn't try to send a heartbeat to the already stopped worker, because its channel has been cancelled at that moment.