### PR TITLE
[RPC] Refactored sessions.

### DIFF
--- a/include/cocaine/api/connect.hpp
+++ b/include/cocaine/api/connect.hpp
@@ -30,8 +30,6 @@
 
 namespace cocaine { namespace api {
 
-namespace signals = boost::signals2;
-
 template<class Tag> class client;
 
 namespace details {
@@ -40,9 +38,6 @@ class basic_client_t {
     // Even though it's a shared pointer, clients do not share session ownership. The reason behind
     // this is to avoid multiple clients being notified on session shutdown and trying to detach it.
     std::shared_ptr<session_t> m_session;
-
-    // Used to unsubscribe this client from session signals on destruction or move.
-    signals::connection m_session_signals;
 
 public:
     template<typename> friend class api::client;
@@ -68,11 +63,7 @@ public:
     // Modifiers
 
     void
-    connect(std::unique_ptr<asio::ip::tcp::socket> socket);
-
-private:
-    void
-    cleanup(const std::error_code& ec);
+    connect(std::unique_ptr<logging::log_t> log, std::unique_ptr<asio::ip::tcp::socket> socket);
 };
 
 } // namespace details

--- a/include/cocaine/detail/chamber.hpp
+++ b/include/cocaine/detail/chamber.hpp
@@ -27,8 +27,8 @@
 #include <boost/accumulators/accumulators.hpp>
 #include <boost/accumulators/statistics/rolling_mean.hpp>
 
-#include <asio/io_service.hpp>
 #include <asio/deadline_timer.hpp>
+#include <asio/io_service.hpp>
 
 #define BOOST_BIND_NO_PLACEHOLDERS
 #include <boost/thread/thread.hpp>

--- a/include/cocaine/detail/engine.hpp
+++ b/include/cocaine/detail/engine.hpp
@@ -23,6 +23,7 @@
 
 #include "cocaine/common.hpp"
 
+#include <asio/deadline_timer.hpp>
 #include <asio/io_service.hpp>
 #include <asio/ip/tcp.hpp>
 
@@ -32,6 +33,8 @@ class session_t;
 
 class execution_unit_t {
     COCAINE_DECLARE_NONCOPYABLE(execution_unit_t)
+
+    class gc_action_t;
 
     std::unique_ptr<logging::log_t> m_log;
 
@@ -43,6 +46,12 @@ class execution_unit_t {
 
     std::shared_ptr<asio::io_service> m_asio;
     std::unique_ptr<io::chamber_t> m_chamber;
+
+    static const unsigned int kCollectionInterval = 60;
+
+    // Collects detached sessions every kCollectionInterval seconds. Normally, session slots will be
+    // reused because of system fd rotation, but for low loads this will help a bit.
+    asio::deadline_timer m_cron;
 
 public:
     explicit
@@ -59,9 +68,6 @@ public:
 private:
     void
     attach_impl(const std::shared_ptr<asio::ip::tcp::socket>& ptr, const io::dispatch_ptr_t& dispatch);
-
-    void
-    on_shutdown(const std::error_code& ec, int socket);
 };
 
 } // namespace cocaine

--- a/include/cocaine/rpc/dispatch.hpp
+++ b/include/cocaine/rpc/dispatch.hpp
@@ -273,24 +273,23 @@ template<class Tag>
 template<class Visitor>
 typename Visitor::result_type
 dispatch<Tag>::process(int id, const Visitor& visitor) const {
-    typename slot_map_t::const_iterator lb, ub;
-    typename slot_map_t::mapped_type slot;
+    typedef typename slot_map_t::mapped_type slot_ptr_type;
 
-    {
-        auto ptr = m_slots.synchronize();
+    const auto slot = m_slots.apply([&](const slot_map_t& mapping) -> slot_ptr_type {
+        typename slot_map_t::const_iterator lb, ub;
 
         // NOTE: Using equal_range() here, instead of find() to check for slot existence and get the
         // slot pointer in one call instead of two.
-        std::tie(lb, ub) = ptr->equal_range(id);
+        std::tie(lb, ub) = mapping.equal_range(id);
 
         if(lb != ub) {
             // NOTE: The slot pointer is copied here, allowing the handling code to unregister slots
             // via dispatch<T>::forget() without pulling the object from underneath itself.
-            slot = lb->second;
+            return lb->second;
         } else {
-            throw cocaine::error_t("unbound type %d slot", id);
+            throw cocaine::error_t("type %d slot wasn't bound to this dispatch", id);
         }
-    }
+    });
 
     return boost::apply_visitor(visitor, slot);
 }

--- a/include/cocaine/rpc/dispatch.hpp
+++ b/include/cocaine/rpc/dispatch.hpp
@@ -215,7 +215,7 @@ struct calling_visitor_t:
             io::type_traits<typename io::event_traits<Event>::argument_type>::unpack(unpacked, args);
         } catch(const msgpack::type_error& e) {
             // TODO: Throw a system_error with some meaningful error code.
-            throw cocaine::error_t("unable to unpack message arguments");
+            throw cocaine::error_t("unable to unpack message arguments - %s", e.what());
         }
 
         // Call the slot with the upstream constrained with the event's upstream protocol type tag.

--- a/include/cocaine/rpc/session.hpp
+++ b/include/cocaine/rpc/session.hpp
@@ -29,25 +29,20 @@
 
 #include <asio/ip/tcp.hpp>
 
-#define BOOST_BIND_NO_PLACEHOLDERS
-#include <boost/signals2/signal.hpp>
-
 namespace cocaine {
-
-namespace signals = boost::signals2;
 
 class session_t:
     public std::enable_shared_from_this<session_t>
 {
-    class channel_t;
-
-    // Discards all the channel dispatches on errors.
-    class discard_action_t;
-
     class pull_action_t;
     class push_action_t;
 
+    class channel_t;
+
     typedef std::map<uint64_t, std::shared_ptr<channel_t>> channel_map_t;
+
+    // Log of last resort.
+    const std::unique_ptr<logging::log_t> log;
 
     // The underlying connection.
 #if defined(__clang__)
@@ -67,12 +62,8 @@ class session_t:
     uint64_t max_channel_id;
 
 public:
-    struct {
-        signals::signal<void(const std::error_code&)> shutdown;
-    } signals;
-
-public:
-    session_t(std::unique_ptr<io::channel<asio::ip::tcp>> transport, const io::dispatch_ptr_t& prototype);
+    session_t(std::unique_ptr<logging::log_t> log,
+              std::unique_ptr<io::channel<asio::ip::tcp>> transport, const io::dispatch_ptr_t& prototype);
 
     // Operations
 
@@ -96,7 +87,7 @@ public:
     // is closed.
 
     void
-    detach();
+    detach(const std::error_code& ec);
 
     // Information
 

--- a/include/cocaine/rpc/upstream.hpp
+++ b/include/cocaine/rpc/upstream.hpp
@@ -42,21 +42,12 @@ public:
     template<class Event, typename... Args>
     void
     send(Args&&... args);
-
-    void
-    drop();
 };
 
 template<class Event, typename... Args>
 void
 basic_upstream_t::send(Args&&... args) {
     session->push(encoded<Event>(channel_id, std::forward<Args>(args)...));
-}
-
-inline
-void
-basic_upstream_t::drop() {
-    session->revoke(channel_id);
 }
 
 // Forwards for the upstream<T> class

--- a/include/cocaine/traits/tuple.hpp
+++ b/include/cocaine/traits/tuple.hpp
@@ -132,7 +132,7 @@ struct sequence_size_error:
     public msgpack::type_error
 {
     sequence_size_error(size_t size, size_t minimal):
-        message(cocaine::format("sequence size mismatch — got %d elements, expected at least %d",
+        message(cocaine::format("sequence size mismatch - got %d element(s), expected at least %d",
             size, minimal
         ))
     { }

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -148,7 +148,7 @@ context_t::insert(const std::string& name, std::unique_ptr<actor_t> service) {
 
         service->run();
 
-        COCAINE_LOG_INFO(m_logger, "service has been started")(
+        COCAINE_LOG_DEBUG(m_logger, "service has been started")(
             "service", name
         );
 
@@ -182,7 +182,7 @@ context_t::remove(const std::string& name) {
         service = std::move(it->second);
         service->terminate();
 
-        COCAINE_LOG_INFO(m_logger, "service has been stopped")(
+        COCAINE_LOG_DEBUG(m_logger, "service has been stopped")(
             "service", name
         );
 
@@ -248,7 +248,7 @@ context_t::bootstrap() {
 
         const auto asio = std::make_shared<asio::io_service>();
 
-        COCAINE_LOG_INFO(m_logger, "starting service");
+        COCAINE_LOG_DEBUG(m_logger, "starting service");
 
         try {
             insert(it->first, std::make_unique<actor_t>(*this, asio, get<api::service_t>(

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -158,6 +158,10 @@ execution_unit_t::attach_impl(const std::shared_ptr<tcp::socket>& ptr, const io:
             socket
         ));
 
+        // Disable Nagle's algorithm, since most of the service clients do not send or receive more
+        // than a couple of kilobytes of data.
+        channel->socket->set_option(tcp::no_delay(true));
+
         auto session_log = std::make_unique<logging::log_t>(*m_log, attribute::set_t({
             attribute::make("endpoint", boost::lexical_cast<std::string>(ptr->remote_endpoint())),
             attribute::make("service",  dispatch->name()),

--- a/src/service/locator.cpp
+++ b/src/service/locator.cpp
@@ -137,6 +137,8 @@ locator_t::connect_client_t::on_link(const std::error_code& ec) {
 
 void
 locator_t::connect_client_t::discard(const std::error_code& ec) const {
+    if(ec.value() == 0) return;
+
     COCAINE_LOG_ERROR(parent->m_log, "remote node has been discarded: [%d] %s", ec.value(), ec.message())(
         "uuid", uuid
     );


### PR DESCRIPTION
Trello: https://trello.com/c/95HRjhQa

* Sessions no longer depend on `boost::signals2`. The shutdown signal wasn't required in the first place, since under highload system will reuse fds fast enough to replace stale sessions in the engine's map, and for quiet times engines will now garbage collect stale sessions every 60 seconds.
* Sessions now log stuff. That means improvements over `uncaught_error` without any details about what error was not actually caught.
* Much more predictable dispatch discard policy. Note that `discard()` call may or may not be accompanied by `std::error_code`.