### PR TITLE
Install all headers as only proper headers are installed by cmake.

### DIFF
--- a/debian/libcocaine-dev.install
+++ b/debian/libcocaine-dev.install
@@ -1,6 +1,1 @@
-usr/include/cocaine/*.hpp
-usr/include/cocaine/api
-usr/include/cocaine/dynamic
-usr/include/cocaine/idl
-usr/include/cocaine/rpc
-usr/include/cocaine/traits
+usr/include/cocaine/*


### PR DESCRIPTION
subj. Also now cocaine/context folder installed correctly.