### PR TITLE
[Bugfix] Multiple service versions in the cluster.

### DIFF
--- a/include/cocaine/api/gateway.hpp
+++ b/include/cocaine/api/gateway.hpp
@@ -26,9 +26,7 @@
 #include "cocaine/locked_ptr.hpp"
 #include "cocaine/repository.hpp"
 
-// TODO: Drop this.
-#include "cocaine/idl/locator.hpp"
-#include "cocaine/rpc/result_of.hpp"
+#include <asio/ip/tcp.hpp>
 
 namespace cocaine { namespace api {
 
@@ -40,19 +38,20 @@ struct gateway_t {
         // Empty.
     }
 
-    typedef result_of<io::locator::resolve>::type metadata_t;
+    typedef std::tuple<std::string, unsigned int> partition_t;
 
     virtual
-    metadata_t
-    resolve(const std::string& name) const = 0;
+    auto
+    resolve(const partition_t& name) const -> std::vector<asio::ip::tcp::endpoint> = 0;
 
     virtual
-    void
-    consume(const std::string& uuid, const std::string& name, const metadata_t& info) = 0;
+    size_t
+    consume(const std::string& uuid,
+            const partition_t& name, const std::vector<asio::ip::tcp::endpoint>& endpoints) = 0;
 
     virtual
-    void
-    cleanup(const std::string& uuid, const std::string& name) = 0;
+    size_t
+    cleanup(const std::string& uuid, const partition_t& name) = 0;
 
 protected:
     gateway_t(context_t&, const std::string& /* name */, const dynamic_t& /* args */) {

--- a/include/cocaine/detail/gateway/adhoc.hpp
+++ b/include/cocaine/detail/gateway/adhoc.hpp
@@ -35,15 +35,15 @@ class adhoc_t:
     // Used in resolve() method, which is const.
     std::default_random_engine mutable m_random_generator;
 
-    struct remote_service_t {
+    struct remote_t {
         std::string uuid;
-        metadata_t  info;
+        std::vector<asio::ip::tcp::endpoint> endpoints;
     };
 
-    typedef std::multimap<std::string, remote_service_t> remote_service_map_t;
+    typedef std::multimap<partition_t, remote_t> remote_map_t;
 
     // TODO: Merge service metadata from remote nodes and check whether it's consistent.
-    synchronized<remote_service_map_t> m_remote_services;
+    synchronized<remote_map_t> m_remotes;
 
 public:
     adhoc_t(context_t& context, const std::string& name, const dynamic_t& args);
@@ -53,15 +53,16 @@ public:
 
     virtual
     auto
-    resolve(const std::string& name) const -> metadata_t;
+    resolve(const partition_t& name) const -> std::vector<asio::ip::tcp::endpoint>;
 
     virtual
-    void
-    consume(const std::string& uuid, const std::string& name, const metadata_t& info);
+    size_t
+    consume(const std::string& uuid,
+            const partition_t& name, const std::vector<asio::ip::tcp::endpoint>& endpoints);
 
     virtual
-    void
-    cleanup(const std::string& uuid, const std::string& name);
+    size_t
+    cleanup(const std::string& uuid, const partition_t& name);
 };
 
 }} // namespace cocaine::gateway

--- a/include/cocaine/detail/service/locator.hpp
+++ b/include/cocaine/detail/service/locator.hpp
@@ -75,6 +75,8 @@ class locator_t:
 
     typedef std::map<std::string, continuum_t> router_map_t;
 
+    typedef std::map<unsigned, io::graph_root_t, std::greater<unsigned>> partition_view_t;
+
     typedef std::map<std::string, api::client<io::locator_tag>> remote_map_t;
     typedef std::map<std::string, streamed<results::connect>>   stream_map_t;
 
@@ -91,19 +93,22 @@ class locator_t:
 
     // Clustering components.
     std::unique_ptr<api::gateway_t> m_gateway;
-    std::shared_ptr<api::cluster_t> m_cluster;
+    std::unique_ptr<api::cluster_t> m_cluster;
 
     // Used to resolve service names against routing groups, based on weights and other metrics.
     synchronized<router_map_t> m_routers;
 
-    // Incoming sessions indexed by uuid. It is required to disambiguate between multiple different
+    // Outgoing sessions indexed by uuid. It is required to disambiguate between multiple different
     // instances on the same host, even if the instance was restarted on the same port.
     synchronized<remote_map_t> m_remotes;
 
-    // Outgoing sessions indexed by uuid.
+    // Snapshot of the cluster service disposition. Synchronized with outgoing streams.
+    std::map<std::string, partition_view_t> m_protocol;
+
+    // Incoming sessions indexed by uuid.
     synchronized<stream_map_t> m_streams;
 
-    // Snapshot of the local service disposition. Synchronized with outgoing streams.
+    // Snapshot of the local service disposition. Synchronized with incoming streams.
     std::map<std::string, results::resolve> m_snapshot;
 
 public:

--- a/include/cocaine/tuple.hpp
+++ b/include/cocaine/tuple.hpp
@@ -66,6 +66,15 @@ struct invoke_impl<index_sequence<Indices...>> {
     template<class F, class... Args>
     static inline
     auto
+    apply(const std::tuple<Args...>& args, F&& callable)
+        -> decltype(callable(std::declval<Args>()...))
+    {
+        return callable(std::move(std::get<Indices>(args))...);
+    }
+
+    template<class F, class... Args>
+    static inline
+    auto
     apply(std::tuple<Args...>&& args, F&& callable)
         -> decltype(callable(std::declval<Args>()...))
     {
@@ -84,6 +93,17 @@ struct fold {
 };
 
 // Function invocation with arguments provided as a tuple
+
+template<class F, class... Args>
+inline
+auto
+invoke(const std::tuple<Args...>& args, F&& callable)
+    -> decltype(callable(std::declval<Args>()...))
+{
+    return aux::invoke_impl<
+        typename make_index_sequence<sizeof...(Args)>::type
+    >::apply(args, std::forward<F>(callable));
+}
 
 template<class F, class... Args>
 inline


### PR DESCRIPTION
When there are more than one service version in the cluster, properly partition service metadata by version and resolve only the latest version. We'll add an ability to request specific versions later.