### PR TITLE
[Bug Fix] Fixed app/service list consistency.

### DIFF
--- a/cocaine-bf.spec
+++ b/cocaine-bf.spec
@@ -2,7 +2,7 @@
 
 Summary:	Cocaine - Core Libraries
 Name:		libcocaine-core3
-Version:	0.12.0.7
+Version:	0.12.0.8
 Release:	1%{?dist}
 
 
@@ -125,6 +125,9 @@ rm -rf %{buildroot}
 %{_sysconfdir}/cocaine/cocaine-default.conf
 
 %changelog
+* Fri Apr 17 2015 Evgeny Safronov <division494@gmail.com> 0.12.0.8-1
+- Bugfix: fixed app vs. published services list inconsistency.
+
 * Wed Apr 08 2015 Andrey Sibiryov <me@kobology.ru> 0.12.0.7-1
 - Remote connections are now retried on failure.
 - Bugfix: endpoints while connecting remotes were corrupted in logs.

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+cocaine-core (0.12.0.8) unstable; urgency=low
+
+  * Bugfix: fixed app vs. published services list inconsistency.
+
+ -- Evgeny Safronov <division494@gmail.com>  Fri, 17 Apr 2015 19:56:54 +0300
+
 cocaine-core (0.12.0.7) unstable; urgency=low
 
   * Remote connections are now retried on failure.

--- a/src/service/node.cpp
+++ b/src/service/node.cpp
@@ -131,7 +131,7 @@ node_t::prototype() const {
 
 void
 node_t::on_start_app(const std::string& name, const std::string& profile) {
-    m_apps.apply([&](std::map<std::string, std::shared_ptr<app_t>>& apps){
+    m_apps.apply([&](std::map<std::string, std::shared_ptr<app_t>>& apps) {
         COCAINE_LOG_DEBUG(m_log, "starting app '%s'", name);
 
         auto it = apps.find(name);

--- a/src/service/node.cpp
+++ b/src/service/node.cpp
@@ -131,21 +131,19 @@ node_t::prototype() const {
 
 void
 node_t::on_start_app(const std::string& name, const std::string& profile) {
-    auto ptr = m_apps.synchronize();
-    auto it = ptr->find(name);
+    m_apps.apply([&](std::map<std::string, std::shared_ptr<app_t>>& apps){
+        COCAINE_LOG_DEBUG(m_log, "starting app '%s'", name);
 
-    COCAINE_LOG_INFO(m_log, "trying to start app '%s'", name);
+        auto it = apps.find(name);
+        if(it != apps.end()) {
+            throw cocaine::error_t("app '%s' is already running", name);
+        }
 
-    if(it != ptr->end()) {
-        throw cocaine::error_t("app '%s' is already running", name);
-    }
+        auto app = std::make_shared<app_t>(m_context, name, profile);
+        app->start();
 
-    std::tie(it, std::ignore) = ptr->insert({
-        name,
-        std::make_shared<app_t>(m_context, name, profile)
+        apps.insert(std::make_pair(name, app));
     });
-
-    it->second->start();
 }
 
 void

--- a/src/service/node/app.cpp
+++ b/src/service/node/app.cpp
@@ -207,7 +207,7 @@ app_t::~app_t() {
 
 void
 app_t::start() {
-    COCAINE_LOG_INFO(m_log, "creating engine '%s'", m_manifest->name);
+    COCAINE_LOG_DEBUG(m_log, "creating engine '%s'", m_manifest->name);
 
     // Start the engine thread.
     try {

--- a/src/service/node/engine.cpp
+++ b/src/service/node/engine.cpp
@@ -179,8 +179,6 @@ engine_t::engine_t(context_t& context, const manifest_t& manifest, const profile
 }
 
 engine_t::~engine_t() {
-    COCAINE_LOG_DEBUG(m_log, "stopping '%s' engine", m_manifest.name);
-
     boost::filesystem::remove(m_manifest.endpoint);
 
     m_loop.post(std::bind(&engine_t::migrate, this, states::stopping));
@@ -188,6 +186,8 @@ engine_t::~engine_t() {
     if(m_thread.joinable()) {
         m_thread.join();
     }
+
+    COCAINE_LOG_DEBUG(m_log, "app '%s' engine has been destroyed", m_manifest.name);
 }
 
 void


### PR DESCRIPTION
When Cocaine was unable to start an app it threw an exception, which wasn't been caught. It led to app/service list inconsistency.

For example:
```
> node.list
> []
>
> node.start_app :http, :default
> [1, "fuck you"]
>
> node.list
> ["http"]
>
> node.pause_app :http
> [1, "app 'http' is not running"]
```

This commit should fix that behavior.