### PR TITLE
[Node] Remove uncleaned unix sockets before binding.

### DIFF
--- a/src/service/node/engine.cpp
+++ b/src/service/node/engine.cpp
@@ -176,11 +176,7 @@ engine_t::engine_t(context_t& context, const manifest_t& manifest, const profile
     );
 
     try {
-        if(boost::filesystem::exists(m_manifest.endpoint)) {
-            COCAINE_LOG_WARNING(m_log, "found uncollected '%s' unix socket", m_manifest.name);
-
-            boost::filesystem::remove(m_manifest.endpoint);
-        }
+        boost::filesystem::remove(m_manifest.endpoint);
     } catch(const boost::filesystem::filesystem_error& err) {
         COCAINE_LOG_WARNING(m_log, "failed to cleanup uncollected '%s' unix socket: %s", m_manifest.name, err.what());
     }


### PR DESCRIPTION
If Cocaine segfaults or is killed by someone it leaves all unix sockets on the FS. If it behaves like this too much often, then the probability of {name}.{pid} conflict grows significantly, which results in impossibility to start any app without manually cleaning `{path}/run/cocaine` directory.

Because we assume that nobody other than Cocaine and its slaves should read/write in `{path}/run/cocaine` directory I propose to check uncollected unix sockets for existence before opening and remove them if found.