### PR TITLE
[Logging] Allow to use mv watcher.

### DIFF
--- a/src/runtime/runtime.cpp
+++ b/src/runtime/runtime.cpp
@@ -264,6 +264,13 @@ main(int argc, char* argv[]) {
     // Available logging sinks.
     typedef boost::mpl::vector<
         blackhole::sink::stream_t,
+        blackhole::sink::files_t<
+            blackhole::sink::files::boost_backend_t,
+            blackhole::sink::rotator_t<
+                blackhole::sink::files::boost_backend_t,
+                blackhole::sink::rotation::watcher::move_t
+            >
+        >,
         blackhole::sink::files_t<>,
         blackhole::sink::syslog_t<logging::priorities>,
         blackhole::sink::socket_t<boost::asio::ip::tcp>,


### PR DESCRIPTION
If a file will be moved/removed the logging system should reopen it.

Sample config:
```
{
  "type": "files",
  "autoflush": true,
  "rotation": {
    "move": true
  }
}
```