### PR TITLE
[Bug Fix] Pack typelists with implicit convertions

### DIFF
--- a/include/cocaine/traits/literal.hpp
+++ b/include/cocaine/traits/literal.hpp
@@ -62,6 +62,30 @@ struct type_traits<literal_t> {
     }
 };
 
+template<>
+struct type_traits<std::string> {
+    template<class Stream>
+    static inline
+    void
+    pack(msgpack::packer<Stream>& target, const literal_t& source) {
+        target.pack_raw(source.size);
+        target.pack_raw_body(source.blob, source.size);
+    }
+
+    template<class Stream>
+    static inline
+    void
+    pack(msgpack::packer<Stream>& target, const std::string& source) {
+        target << source;
+    }
+
+    static inline
+    void
+    unpack(const msgpack::object& unpacked, std::string& target) {
+        unpacked >> target;
+    }
+};
+
 }} // namespace cocaine::io
 
 #endif

--- a/include/cocaine/traits/tuple.hpp
+++ b/include/cocaine/traits/tuple.hpp
@@ -253,14 +253,15 @@ private:
     pack_sequence(msgpack::packer<Stream>& target, const Head& head, const Tail&... tail) {
         typedef typename pristine<Head>::type type;
         typedef typename boost::mpl::deref<It>::type element_type;
+        typedef typename details::unwrap_type<element_type>::type unwrapped_element_type;
 
         static_assert(
-            std::is_convertible<type, typename details::unwrap_type<element_type>::type>::value,
+            std::is_convertible<type, unwrapped_element_type>::value,
             "sequence element type mismatch"
         );
 
         // Pack the current element using the correct packer.
-        type_traits<type>::pack(target, head);
+        type_traits<unwrapped_element_type>::pack(target, head);
 
         // Recurse to the next element.
         pack_sequence<typename boost::mpl::next<It>::type>(target, tail...);


### PR DESCRIPTION
Given:

 - T and U, where T is convertible to U.
 - An event with typelist<U, Args...>.
 - Arguments v: T, other: Args...

This commit fixes improper behavior when an argument of type T is packed using `type_traits<T>(v)` instead of `type_traits<U>(v)`.

Without this change the https://github.com/cocaine/cocaine-core/blob/kobolog/error-categories/include/cocaine/rpc/slot/blocking.hpp#L56 for example invokes improper behavior, packing an int instead of calling conversion constructor.