### PR TITLE
Forbid empty groups as like as groups with zero total weights.

### DIFF
--- a/src/service/locator/routing.cpp
+++ b/src/service/locator/routing.cpp
@@ -45,6 +45,16 @@ continuum_t::continuum_t(std::unique_ptr<logging::log_t> log, const stored_type&
         weight
     );
 
+    if (!length) {
+        throw cocaine::error_t("group must not be empty");
+    }
+
+    // each item in a routing group has its own positive integer weight,
+    // so the total weight must be more than 0
+    if (weight < std::numeric_limits<double>::epsilon()) {
+        throw cocaine::error_t("the total weight of group must be positive");
+    }
+
     union digest_t {
         char       hashed[16];
         point_type points[sizeof(hashed) / sizeof(point_type)];


### PR DESCRIPTION
Both of them make no sense from the routing point.