### PR TITLE
Fixed string literals binding.

### DIFF
--- a/include/cocaine/rpc/asio/encoder.hpp
+++ b/include/cocaine/rpc/asio/encoder.hpp
@@ -161,7 +161,7 @@ struct encoded:
 {
     template<class... Args>
     encoded(uint64_t channel_id, Args&&... args):
-        unbound_message_t(std::bind(&encoder_t::tether<Event, Args...>,
+        unbound_message_t(std::bind(&encoder_t::tether<Event, typename std::decay<Args>::type...>,
             std::placeholders::_1,
             channel_id,
             std::forward<Args>(args)...))


### PR DESCRIPTION
Otherwise stuff like `upstream.send<protocol::write>(ec, "fuck you");` won't work.