### PR TITLE
Logging: no more trace.

### DIFF
--- a/include/cocaine/forwards.hpp
+++ b/include/cocaine/forwards.hpp
@@ -88,11 +88,10 @@ struct protocol;
 namespace cocaine { namespace logging {
 
 enum priorities: int {
-    trace,
-    debug,
-    info,
-    warning,
-    error
+    debug   =  0,
+    info    =  1,
+    warning =  2,
+    error   =  3
 };
 
 typedef blackhole::verbose_logger_t<logging::priorities> logger_t;

--- a/include/cocaine/logging.hpp
+++ b/include/cocaine/logging.hpp
@@ -31,9 +31,6 @@
     if(auto _record_ = ::cocaine::logging::detail::logger_ptr(_log_)->open_record(_level_)) \
         ::blackhole::aux::logger::make_pusher(*(::cocaine::logging::detail::logger_ptr(_log_)), _record_, __VA_ARGS__)
 
-#define COCAINE_LOG_TRACE(_log_, ...) \
-    COCAINE_LOG(_log_, ::cocaine::logging::trace, __VA_ARGS__)
-
 #define COCAINE_LOG_DEBUG(_log_, ...) \
     COCAINE_LOG(_log_, ::cocaine::logging::debug, __VA_ARGS__)
 

--- a/src/context/config.cpp
+++ b/src/context/config.cpp
@@ -296,9 +296,7 @@ struct dynamic_converter<config_t::logging_t> {
     static inline
     logging::priorities
     logmask(const std::string& verbosity) {
-        if(verbosity == "trace") {
-            return logging::trace;
-        } else if(verbosity == "debug") {
+        if(verbosity == "debug") {
             return logging::debug;
         } else if(verbosity == "warning") {
             return logging::warning;
@@ -413,4 +411,3 @@ int
 config_t::versions() {
     return COCAINE_VERSION;
 }
-

--- a/src/runtime/logging.cpp
+++ b/src/runtime/logging.cpp
@@ -66,7 +66,7 @@ namespace cocaine { namespace logging {
 
 void
 map_severity(blackhole::aux::attachable_ostringstream& stream, const logging::priorities& level) {
-    static const std::array<const char*, 5> describe = {{ "T", "D", "I", "W", "E" }};
+    static const std::array<const char*, 4> describe = {{ "D", "I", "W", "E" }};
 
     const size_t value = static_cast<size_t>(level);
 


### PR DESCRIPTION
Accidentally we have broken an API, so we have to rollback
to prevent further damage.

Also the logging priorities now have strictly associated
numbers, cause they are part of public API.