### PR TITLE
Fix(errors): remove excess argument.

### DIFF
--- a/src/errors.cpp
+++ b/src/errors.cpp
@@ -210,7 +210,7 @@ make_error_code(security_errors code) -> std::error_code {
 
 std::string
 to_string(const std::system_error& e) {
-    return cocaine::format("[%d] %s", e.code().value(), e.code().message(), e.what());
+    return cocaine::format("[%d] %s", e.code().value(), e.what());
 }
 
 const std::error_code


### PR DESCRIPTION
Now argument count properly corresponds the pattern.

Previously:
```
[E]: unable to announce local endpoints: <unable to format message - boost::too_many_args: format-string referred to less arguments than were passed> [source: locator:cluster]
```

Becomes:
```
[E]: unable to announce local endpoints: [65] send_to: No route to host [source: locator:cluster]
```