### PR TITLE
Fix(engine): fixed infinite hanging on engine shutdown.

### DIFF
--- a/include/cocaine/detail/engine.hpp
+++ b/include/cocaine/detail/engine.hpp
@@ -52,7 +52,7 @@ class execution_unit_t {
 
     // Collects detached sessions every kCollectionInterval seconds. Normally, session slots will be
     // reused because of system fd rotation, but for low loads this will help a bit.
-    asio::deadline_timer m_cron;
+    std::unique_ptr<asio::deadline_timer> m_cron;
 
 public:
     explicit


### PR DESCRIPTION
Just canceling timer is not enough to be sure that it's stopped.

ASIO `timer::cancel` returns number of actually cancelled completion
handlers. Depending on timeout resolution it may return 0, which means
that completion handler has already been posted into the event loop and
it cannot be cancelled. Thus, it would be fired and reschedule timer
again. This led to the infinite hanging on joining thread while the event
loop processing repeating timer events.

This commit adds timer explicit lifetime tracking before asynchronous
waiting.