### PR TITLE
fix(locator): make router streams auto disposable

### DIFF
--- a/include/cocaine/detail/service/locator.hpp
+++ b/include/cocaine/detail/service/locator.hpp
@@ -72,6 +72,7 @@ class locator_t:
 {
     class connect_sink_t;
     class publish_slot_t;
+    class routing_slot_t;
 
     typedef std::map<std::string, continuum_t> rg_map_t;
 

--- a/include/cocaine/idl/locator.hpp
+++ b/include/cocaine/idl/locator.hpp
@@ -141,8 +141,20 @@ struct publish {
     >::type argument_type;
 };
 
+struct routing_tag;
 struct routing {
+    struct discard {
+        typedef locator::routing_tag tag;
+
+        static const char* alias() {
+            return "discard";
+        }
+
+        typedef void upstream_type;
+    };
+
     typedef locator_tag tag;
+    typedef locator::routing_tag dispatch_type;
 
     static const char* alias() {
         return "routing";
@@ -164,7 +176,7 @@ struct routing {
 template<>
 struct protocol<locator_tag> {
     typedef boost::mpl::int_<
-        2
+        3
     >::type version;
 
     typedef boost::mpl::list<
@@ -177,6 +189,17 @@ struct protocol<locator_tag> {
     >::type messages;
 
     typedef locator scope;
+};
+
+template<>
+struct protocol<locator::routing_tag> {
+    typedef boost::mpl::int_<
+        1
+    >::type version;
+
+    typedef boost::mpl::list<
+        locator::routing::discard
+    >::type messages;
 };
 
 template<>


### PR DESCRIPTION
This commit makes outgoing streams for routers auto disposable. Without
this change the streams are not collected until unsuccessful write attempt.

In our production we have about 50k dead streams which made the Locator
completely freeze attempting to notify them all.

Also this commit allows clients to unsubscribe manually without
transport destruction.

Moreover this makes the protocol more clean.

Also added more logs.