### PR TITLE
fix(cmake): hide -Wunused-local-typedef for asio

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,13 +52,13 @@ INCLUDE_DIRECTORIES(
     ${LIBLTDL_INCLUDE_DIRS})
 
 # If not included as SYSTEM, these libs would emit 100500 warnings.
-INCLUDE_DIRECTORIES(BEFORE
-    SYSTEM ${PROJECT_SOURCE_DIR}/foreign/backward-cpp)
+INCLUDE_DIRECTORIES(BEFORE SYSTEM
+    ${PROJECT_SOURCE_DIR}/foreign/asio/asio/include
+    ${PROJECT_SOURCE_DIR}/foreign/backward-cpp)
 
 INCLUDE_DIRECTORIES(BEFORE
     ${PROJECT_SOURCE_DIR}/foreign/blackhole/src
     ${PROJECT_SOURCE_DIR}/foreign/rapidjson/include
-    ${PROJECT_SOURCE_DIR}/foreign/asio/asio/include
     ${PROJECT_SOURCE_DIR}/include)
 
 LINK_DIRECTORIES(


### PR DESCRIPTION
On newer clang there is new warning check, which is triggered by ASIO headers.