### PR TITLE
style(logs): consistency for logging prefixes

### DIFF
--- a/src/actor.cpp
+++ b/src/actor.cpp
@@ -113,9 +113,7 @@ actor_t::actor_t(context_t& context, const std::shared_ptr<io_service>& asio,
                  std::unique_ptr<basic_dispatch_t> prototype)
 :
     m_context(context),
-    m_log(context.log("core:asio", {
-        attribute::make("service", prototype->name())
-    })),
+    m_log(context.log("core/asio", {{"service", prototype->name()}})),
     m_asio(asio),
     m_prototype(std::move(prototype))
 { }
@@ -124,9 +122,7 @@ actor_t::actor_t(context_t& context, const std::shared_ptr<io_service>& asio,
                  std::unique_ptr<api::service_t> service)
 :
     m_context(context),
-    m_log(context.log("core:asio", {
-        attribute::make("service", service->prototype().name())
-    })),
+    m_log(context.log("core/asio", {{"service", service->prototype().name()}})),
     m_asio(asio)
 {
     const basic_dispatch_t* prototype = &service->prototype();

--- a/src/actor_unix.cpp
+++ b/src/actor_unix.cpp
@@ -86,7 +86,7 @@ unix_actor_t::unix_actor_t(cocaine::context_t& context,
                            std::unique_ptr<cocaine::io::basic_dispatch_t> prototype) :
     m_context(context),
     endpoint(std::move(endpoint)),
-    m_log(context.log("core::io", {{ "app", prototype->name() }})),
+    m_log(context.log("core/asio", {{ "service", prototype->name() }})),
     m_asio(asio),
     m_prototype(std::move(prototype)),
     fact(std::move(fact)),

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -103,10 +103,8 @@ execution_unit_t::gc_action_t::finalize(const std::error_code& ec) {
 
 execution_unit_t::execution_unit_t(context_t& context):
     m_asio(new io_service()),
-    m_chamber(new chamber_t("core:asio", m_asio)),
-    m_log(context.log("core:asio", {
-        attribute::make("engine", m_chamber->thread_id())
-    })),
+    m_chamber(new chamber_t("core/asio", m_asio)),
+    m_log(context.log("core/asio", {{"engine", m_chamber->thread_id()}})),
     m_cron(new asio::deadline_timer(*m_asio))
 {
     m_asio->post(std::bind(&gc_action_t::operator(),


### PR DESCRIPTION
This is handy for logging postprocessors which can create separate directory depending on attribute value.

- Also use uniform initialization for logging attributes, it makes the code cleaner.
- Thread name is also touched.