### PR TITLE
Grand Cleanup & Stuff

### DIFF
--- a/include/cocaine/api/gateway.hpp
+++ b/include/cocaine/api/gateway.hpp
@@ -33,12 +33,14 @@ namespace cocaine { namespace api {
 struct gateway_t {
     typedef gateway_t category_type;
 
+    // Partition is a (service name, version) tuple. It is used to partition same service across
+    // cluster by version, i.e. keeping different versions of the same service protocol separate.
+    typedef std::tuple<std::string, unsigned int> partition_t;
+
     virtual
    ~gateway_t() {
         // Empty.
     }
-
-    typedef std::tuple<std::string, unsigned int> partition_t;
 
     virtual
     auto

--- a/include/cocaine/api/storage.hpp
+++ b/include/cocaine/api/storage.hpp
@@ -129,10 +129,12 @@ struct category_traits<storage_t> {
             ptr_type instance;
 
             instances.apply([&](std::map<std::string, std::weak_ptr<storage_t>>& instances) {
-                if((instance = instances[name].lock()) == nullptr) {
-                    instance = std::make_shared<T>(context, name, args);
-                    instances[name] = instance;
+                if((instance = instances[name].lock()) != nullptr) {
+                    return;
                 }
+
+                instance = std::make_shared<T>(context, name, args);
+                instances[name] = instance;
             });
 
             return instance;

--- a/include/cocaine/common.hpp
+++ b/include/cocaine/common.hpp
@@ -39,14 +39,17 @@
 #include <boost/assert.hpp>
 #include <boost/version.hpp>
 
+#define COCAINE_UNUSED_(parameter)          \
+    parameter __attribute__((unused))
+
+#define COCAINE_UNREACHABLE                 \
+    __builtin_unreachable
+
 #define COCAINE_DECLARE_NONCOPYABLE(type)   \
     type(const type& other) = delete;       \
                                             \
     type&                                   \
     operator=(const type& other) = delete;
-
-#define COCAINE_UNUSED_(parameter)          \
-    parameter __attribute__((unused))
 
 #include "cocaine/errors.hpp"
 #include "cocaine/forwards.hpp"

--- a/include/cocaine/common.hpp
+++ b/include/cocaine/common.hpp
@@ -39,17 +39,17 @@
 #include <boost/assert.hpp>
 #include <boost/version.hpp>
 
-#define COCAINE_UNUSED_(parameter)          \
-    parameter __attribute__((unused))
-
-#define COCAINE_UNREACHABLE                 \
-    __builtin_unreachable
-
 #define COCAINE_DECLARE_NONCOPYABLE(type)   \
     type(const type& other) = delete;       \
                                             \
     type&                                   \
     operator=(const type& other) = delete;
+
+#define COCAINE_UNREACHABLE                 \
+    __builtin_unreachable
+
+#define COCAINE_UNUSED_(parameter)          \
+    parameter __attribute__((unused))
 
 #include "cocaine/errors.hpp"
 #include "cocaine/forwards.hpp"

--- a/include/cocaine/context.hpp
+++ b/include/cocaine/context.hpp
@@ -38,10 +38,12 @@
 
 namespace cocaine {
 
-// Context
-
+class quote_t;
 class actor_t;
+
 class execution_unit_t;
+
+// Context
 
 class context_t {
     COCAINE_DECLARE_NONCOPYABLE(context_t)
@@ -91,7 +93,7 @@ public:
     remove(const std::string& name) -> std::unique_ptr<actor_t>;
 
     auto
-    locate(const std::string& name) const -> boost::optional<const actor_t&>;
+    locate(const std::string& name) const -> boost::optional<quote_t>;
 
     // Signals API
 

--- a/include/cocaine/context.hpp
+++ b/include/cocaine/context.hpp
@@ -48,8 +48,7 @@ class context_t {
 
     typedef std::deque<std::pair<std::string, std::unique_ptr<actor_t>>> service_list_t;
 
-    // TODO: There was an idea to use the Repository to enable pluggable sinks and whatever else for
-    // for the Blackhole, when all the common stuff is extracted to a separate library.
+    // The root logger.
     std::unique_ptr<logging::log_t> m_log;
 
     // NOTE: This is the first object in the component tree, all the other dynamic components, be it

--- a/include/cocaine/context.hpp
+++ b/include/cocaine/context.hpp
@@ -65,7 +65,7 @@ class context_t {
     synchronized<service_list_t> m_services;
 
     // Context signalling hub.
-    retroactive_signal<io::context_tag> m_signals;
+    synchronized<signal<io::context_tag>> m_signals;
 
 public:
     const config_t config;
@@ -99,7 +99,7 @@ public:
 
     void
     listen(const std::shared_ptr<dispatch<io::context_tag>>& slot, asio::io_service& asio) {
-        m_signals.listen(slot, asio);
+        m_signals->listen(slot, asio);
     }
 
     // Network I/O

--- a/include/cocaine/context.hpp
+++ b/include/cocaine/context.hpp
@@ -50,7 +50,7 @@ class context_t {
 
     typedef std::deque<std::pair<std::string, std::unique_ptr<actor_t>>> service_list_t;
 
-    // The root logger.
+    // The root log.
     std::unique_ptr<logging::log_t> m_log;
 
     // NOTE: This is the first object in the component tree, all the other dynamic components, be it

--- a/include/cocaine/context.hpp
+++ b/include/cocaine/context.hpp
@@ -95,6 +95,9 @@ public:
     auto
     locate(const std::string& name) const -> boost::optional<quote_t>;
 
+    auto
+    snapshot() const -> std::map<std::string, quote_t>;
+
     // Signals API
 
     void

--- a/include/cocaine/context/signal.hpp
+++ b/include/cocaine/context/signal.hpp
@@ -82,6 +82,9 @@ public:
             try {
                 target->process(io::event_traits<Event>::id, visitor);
             } catch(const std::system_error& e) {
+                // Propagate exceptions to the ASIO thread even though it
+                // will terminate the Runtime. It is better than silently
+                // ignoring signal handling exceptions.
                 if(e.code() != error::slot_not_found) throw;
             }
         });
@@ -90,7 +93,9 @@ public:
     }
 
     void
-    discard() { if(auto target = weak.lock()) target->discard({ }); }
+    discard() {
+        if(auto target = weak.lock()) target->discard(std::error_code());
+    }
 };
 
 } // namespace aux

--- a/include/cocaine/context/signal.hpp
+++ b/include/cocaine/context/signal.hpp
@@ -47,20 +47,16 @@ struct async_visitor:
 
     template<class Other>
     result_type
-    operator()(const std::shared_ptr<io::basic_slot<Other>>& COCAINE_UNUSED_(slot)) const {
+    operator()(const std::shared_ptr<io::basic_slot<Other>> COCAINE_UNUSED_(slot)) const {
         __builtin_unreachable();
     }
 
     result_type
-    operator()(const std::shared_ptr<io::basic_slot<Event>>& slot) const {
-        auto args = this->args;
-
-        asio.post([=]() mutable {
-            (*slot)(std::move(args), upstream<void>());
-        });
+    operator()(const std::shared_ptr<io::basic_slot<Event>> slot) {
+        asio.post([=]() mutable { (*slot)(std::move(args), upstream<void>()); });
     }
 
-    const tuple_type& args;
+    const tuple_type  args;
     asio::io_service& asio;
 };
 

--- a/include/cocaine/context/signal.hpp
+++ b/include/cocaine/context/signal.hpp
@@ -74,10 +74,11 @@ public:
     template<class Event>
     result_type
     operator()(const io::frozen<Event>& event) const {
-        const auto target  = weak.lock();
-        const auto visitor = async_visitor<Event>(event.tuple);
+        const auto target = weak.lock();
 
         if(target) asio.post([=]() {
+            const auto visitor = async_visitor<Event>(event.tuple);
+
             try {
                 target->process(io::event_traits<Event>::id, visitor);
             } catch(const std::system_error& e) {

--- a/include/cocaine/detail/chamber.hpp
+++ b/include/cocaine/detail/chamber.hpp
@@ -38,6 +38,11 @@ class chamber_t {
     class named_runnable_t;
     class stats_periodic_action_t;
 
+    typedef boost::accumulators::accumulator_set<
+        double,
+        boost::accumulators::features<boost::accumulators::tag::rolling_mean>
+    > load_average_t;
+
     static const unsigned int kCollectionInterval = 2;
 
     const std::string name;
@@ -48,11 +53,6 @@ class chamber_t {
 
     // This thread will run the reactor's event loop until terminated.
     std::unique_ptr<boost::thread> thread;
-
-    typedef boost::accumulators::accumulator_set<
-        double,
-        boost::accumulators::features<boost::accumulators::tag::rolling_mean>
-    > load_average_t;
 
     // Rolling resource usage mean over last minute.
     synchronized<load_average_t> load_acc1;

--- a/include/cocaine/detail/engine.hpp
+++ b/include/cocaine/detail/engine.hpp
@@ -46,13 +46,13 @@ class execution_unit_t {
     std::shared_ptr<asio::io_service> m_asio;
     std::unique_ptr<io::chamber_t> m_chamber;
 
-    // Initialized here because of the dependency on the io::chamber_t's thread ID.
+    // Initialized here because of the dependency on the io::chamber_t's thread_id().
     const std::unique_ptr<logging::log_t> m_log;
 
     static const unsigned int kCollectionInterval = 60;
 
-    // Collects detached sessions every kCollectionInterval seconds. Normally, session slots will be
-    // reused because of system fd rotation, but for low loads this will help a bit.
+    // Collects detached sessions every kCollectionInterval seconds. Normally, slots
+    // will be reused with system fd rotation, but on low loads this will help a bit.
     std::unique_ptr<asio::deadline_timer> m_cron;
 
 public:

--- a/include/cocaine/detail/gateway/adhoc.hpp
+++ b/include/cocaine/detail/gateway/adhoc.hpp
@@ -42,7 +42,7 @@ class adhoc_t:
 
     typedef std::multimap<partition_t, remote_t> remote_map_t;
 
-    // TODO(@kobolog): Make sure that remote service metadata is consistent across the cluster.
+    // TODO(@kobolog): Make sure that remote service info is consistent across the cluster.
     synchronized<remote_map_t> m_remotes;
 
 public:

--- a/include/cocaine/detail/gateway/adhoc.hpp
+++ b/include/cocaine/detail/gateway/adhoc.hpp
@@ -42,7 +42,7 @@ class adhoc_t:
 
     typedef std::multimap<partition_t, remote_t> remote_map_t;
 
-    // TODO: Make sure that remote service metadata is consistent across the whole cluster.
+    // TODO(@kobolog): Make sure that remote service metadata is consistent across the cluster.
     synchronized<remote_map_t> m_remotes;
 
 public:

--- a/include/cocaine/detail/service/locator.hpp
+++ b/include/cocaine/detail/service/locator.hpp
@@ -74,13 +74,9 @@ class locator_t:
     class publish_slot_t;
     class routing_slot_t;
 
-    typedef std::map<std::string, continuum_t> rg_map_t;
-
     typedef std::map<std::string, std::shared_ptr<session<asio::ip::tcp>>> client_map_t;
 
-    typedef std::map<unsigned int, io::graph_root_t,
-        std::greater<unsigned int>
-    > partition_view_t;
+    typedef std::map<std::string, continuum_t> rg_map_t;
 
     typedef std::map<std::string, streamed<results::connect>> remote_map_t;
     typedef std::map<std::string, streamed<results::routing>> router_map_t;
@@ -103,21 +99,22 @@ class locator_t:
     // Used to resolve service names against routing groups, based on weights and other metrics.
     synchronized<rg_map_t> m_rgs;
 
+    // Outgoing router streams indexed by some arbitrary router-provided uuid.
+    synchronized<router_map_t> m_routers;
+
     // Incoming remote locator streams indexed by uuid. Uuid is required to disambiguate between
     // multiple different instances on the same host and port (in case it was restarted).
     synchronized<client_map_t> m_clients;
 
     // Snapshot of the cluster service disposition. Synchronized with incoming streams.
-    std::map<std::string, partition_view_t> m_aggregate;
+    std::map<std::string,
+             std::map<unsigned int, io::graph_root_t, std::greater<unsigned int>>> m_aggregate;
 
     // Outgoing remote locator streams indexed by node uuid.
     synchronized<remote_map_t> m_remotes;
 
     // Snapshots of the local service states. Synchronized with outgoing remote streams.
     std::map<std::string, results::resolve> m_snapshots;
-
-    // Outgoing router streams indexed by some arbitrary router-provided uuid.
-    synchronized<router_map_t> m_routers;
 
 public:
     locator_t(context_t& context, asio::io_service& asio, const std::string& name, const dynamic_t& args);

--- a/include/cocaine/detail/service/locator.hpp
+++ b/include/cocaine/detail/service/locator.hpp
@@ -99,9 +99,6 @@ class locator_t:
     // Used to resolve service names against routing groups, based on weights and other metrics.
     synchronized<rg_map_t> m_rgs;
 
-    // Outgoing router streams indexed by some arbitrary router-provided uuid.
-    synchronized<router_map_t> m_routers;
-
     // Incoming remote locator streams indexed by uuid. Uuid is required to disambiguate between
     // multiple different instances on the same host and port (in case it was restarted).
     synchronized<client_map_t> m_clients;
@@ -113,8 +110,8 @@ class locator_t:
     // Outgoing remote locator streams indexed by node uuid.
     synchronized<remote_map_t> m_remotes;
 
-    // Snapshots of the local service states. Synchronized with outgoing remote streams.
-    std::map<std::string, results::resolve> m_snapshots;
+    // Outgoing router streams indexed by some arbitrary router-provided uuid.
+    synchronized<router_map_t> m_routers;
 
 public:
     locator_t(context_t& context, asio::io_service& asio, const std::string& name, const dynamic_t& args);
@@ -164,10 +161,8 @@ private:
 
     // Context signals
 
-    enum class modes { exposed, removed };
-
     void
-    on_service(const std::string& name, const results::resolve& meta, modes mode);
+    on_service(const std::string& name, const results::resolve& info);
 
     void
     on_context_shutdown();

--- a/include/cocaine/detail/service/locator.hpp
+++ b/include/cocaine/detail/service/locator.hpp
@@ -76,16 +76,11 @@ class locator_t:
 
     typedef std::map<std::string, continuum_t> rg_map_t;
 
-    class uplink_t
-    {
-    public:
-        std::vector<asio::ip::tcp::endpoint> endpoints;
-        std::shared_ptr<session<asio::ip::tcp>> ptr;
-    };
+    typedef std::map<std::string, std::shared_ptr<session<asio::ip::tcp>>> client_map_t;
 
-    typedef std::map<std::string, uplink_t> client_map_t;
-
-    typedef std::map<unsigned int, io::graph_root_t, std::greater<unsigned int>> partition_view_t;
+    typedef std::map<unsigned int, io::graph_root_t,
+        std::greater<unsigned int>
+    > partition_view_t;
 
     typedef std::map<std::string, streamed<results::connect>> remote_map_t;
     typedef std::map<std::string, streamed<results::routing>> router_map_t;
@@ -182,12 +177,5 @@ private:
 };
 
 }} // namespace cocaine::service
-
-namespace cocaine { namespace error {
-
-auto
-locator_category() -> const std::error_category&;
-
-}} // namespace cocaine::error
 
 #endif

--- a/include/cocaine/errors.hpp
+++ b/include/cocaine/errors.hpp
@@ -109,8 +109,8 @@ struct error_t:
     template<class E, class... Args,
              class = typename std::enable_if<std::is_error_code_enum<E>::value ||
                                              std::is_error_condition_enum<E>::value>::type>
-    error_t(const E err, const std::string& e, const Args&... args):
-        std::system_error(std::make_error_code(err), cocaine::format(e, args...))
+    error_t(const E error_id, const std::string& e, const Args&... args):
+        std::system_error(make_error_code(error_id), cocaine::format(e, args...))
     { }
 };
 

--- a/include/cocaine/format.hpp
+++ b/include/cocaine/format.hpp
@@ -27,15 +27,15 @@ namespace cocaine { namespace aux {
 
 static inline
 std::string
-substitute(boost::format&& message) {
-    return message.str();
+substitute(boost::format&& formatter) {
+    return formatter.str();
 }
 
-template<typename T, class... Args>
+template<class T, class... Args>
 static inline
 std::string
-substitute(boost::format&& message, T&& argument, Args&&... args) {
-    return substitute(std::move(message % std::forward<T>(argument)), std::forward<Args>(args)...);
+substitute(boost::format&& formatter, const T& argument, const Args&... args) {
+    return substitute(std::move(formatter % argument), args...);
 }
 
 } // namespace aux
@@ -43,11 +43,11 @@ substitute(boost::format&& message, T&& argument, Args&&... args) {
 template<class... Args>
 static inline
 std::string
-format(const std::string& format, Args&&... args) {
+format(const std::string& format, const Args&... args) {
     try {
-        return aux::substitute(std::move(boost::format(format)), std::forward<Args>(args)...);
+        return aux::substitute(boost::format(format), args...);
     } catch(const boost::io::format_error& e) {
-        return aux::substitute(std::move(boost::format("<invalid string format - %s>")), e.what());
+        return aux::substitute(boost::format("<format error - %s>"), e.what());
     }
 }
 

--- a/include/cocaine/format.hpp
+++ b/include/cocaine/format.hpp
@@ -45,9 +45,9 @@ static inline
 std::string
 format(const std::string& format, const Args&... args) {
     try {
-        return aux::substitute(boost::format(format), args...);
+        return aux::substitute(std::move(boost::format(format)), args...);
     } catch(const boost::io::format_error& e) {
-        return aux::substitute(boost::format("<format error - %s>"), e.what());
+        return aux::substitute(std::move(boost::format("<format error - %s>")), e.what());
     }
 }
 

--- a/include/cocaine/format.hpp
+++ b/include/cocaine/format.hpp
@@ -34,8 +34,8 @@ substitute(boost::format&& message) {
 template<typename T, class... Args>
 static inline
 std::string
-substitute(boost::format&& message, const T& argument, const Args&... args) {
-    return substitute(std::move(message % argument), args...);
+substitute(boost::format&& message, T&& argument, Args&&... args) {
+    return substitute(std::move(message % std::forward<T>(argument)), std::forward<Args>(args)...);
 }
 
 } // namespace aux
@@ -43,11 +43,11 @@ substitute(boost::format&& message, const T& argument, const Args&... args) {
 template<class... Args>
 static inline
 std::string
-format(const std::string& format, const Args&... args) {
+format(const std::string& format, Args&&... args) {
     try {
-        return aux::substitute(std::move(boost::format(format)), args...);
+        return aux::substitute(std::move(boost::format(format)), std::forward<Args>(args)...);
     } catch(const boost::io::format_error& e) {
-        return aux::substitute(std::move(boost::format("<unable to format message - %s>")), e.what());
+        return aux::substitute(std::move(boost::format("<invalid string format - %s>")), e.what());
     }
 }
 

--- a/include/cocaine/idl/locator.hpp
+++ b/include/cocaine/idl/locator.hpp
@@ -136,7 +136,7 @@ struct publish {
         std::string,
      /* External service endpoints. */
         std::vector<asio::ip::tcp::endpoint>,
-     /* Service metadata, if the external service is using native protocol. */
+     /* Service info, if the external service is using native protocol. */
         optional<std::tuple<unsigned int, graph_root_t>>
     >::type argument_type;
 };

--- a/include/cocaine/repository.hpp
+++ b/include/cocaine/repository.hpp
@@ -114,7 +114,7 @@ repository_t::get(const std::string& name, Args&&... args) const {
         throw std::system_error(error::component_not_found, name);
     }
 
-    auto it = m_categories.at(id).find(name);
+    const auto it = m_categories.at(id).find(name);
 
     // TEST: Ensure that the plugin is of the actually specified category.
     BOOST_ASSERT(it->second->type_id() == typeid(Category));

--- a/include/cocaine/repository.hpp
+++ b/include/cocaine/repository.hpp
@@ -114,7 +114,7 @@ repository_t::get(const std::string& name, Args&&... args) const {
         throw std::system_error(error::component_not_found, name);
     }
 
-    const auto it = m_categories.at(id).find(name);
+    auto it = m_categories.at(id).find(name);
 
     // TEST: Ensure that the plugin is of the actually specified category.
     BOOST_ASSERT(it->second->type_id() == typeid(Category));

--- a/include/cocaine/repository.hpp
+++ b/include/cocaine/repository.hpp
@@ -143,7 +143,7 @@ repository_t::insert(const std::string& name) {
     const auto id = typeid(category_type).name();
 
     if(m_categories.count(id) && m_categories.at(id).count(name)) {
-        throw std::system_error(error::duplicate_component);
+        throw std::system_error(error::duplicate_component, name);
     }
 
     COCAINE_LOG_DEBUG(m_log, "registering component '%s' in category '%s'",

--- a/include/cocaine/rpc/actor.hpp
+++ b/include/cocaine/rpc/actor.hpp
@@ -24,9 +24,9 @@
 #include "cocaine/common.hpp"
 #include "cocaine/locked_ptr.hpp"
 
-#include "cocaine/rpc/graph.hpp"
-
 #include <asio/ip/tcp.hpp>
+
+#include "cocaine/rpc/graph.hpp"
 
 namespace cocaine {
 

--- a/include/cocaine/rpc/actor.hpp
+++ b/include/cocaine/rpc/actor.hpp
@@ -24,9 +24,19 @@
 #include "cocaine/common.hpp"
 #include "cocaine/locked_ptr.hpp"
 
+#include "cocaine/rpc/graph.hpp"
+
 #include <asio/ip/tcp.hpp>
 
 namespace cocaine {
+
+class quote_t
+{
+public:
+    std::vector<asio::ip::tcp::endpoint> location;
+    unsigned int version;
+    io::graph_root_t protocol;
+};
 
 class actor_t {
     COCAINE_DECLARE_NONCOPYABLE(actor_t)

--- a/include/cocaine/rpc/dispatch.hpp
+++ b/include/cocaine/rpc/dispatch.hpp
@@ -45,6 +45,8 @@ template<class Tag> class dispatch;
 
 namespace io {
 
+class rpc_t;
+
 class basic_dispatch_t {
     // The name of the service which this protocol implementation belongs to. Mostly used for logs,
     // and for synchronization stuff in the Locator Service.
@@ -62,8 +64,21 @@ public:
     // an empty optional - recurrent transition (i.e. no transition at all).
 
     virtual
-    boost::optional<dispatch_ptr_t>
-    process(const decoder_t::message_type& message, const upstream_ptr_t& upstream) const = 0;
+    auto
+    process(int id, const rpc_t& rpc) const -> boost::optional<dispatch_ptr_t> = 0;
+
+    // Observers
+
+    auto
+    name() const -> std::string;
+
+    virtual
+    auto
+    root() const -> const graph_root_t& = 0;
+
+    virtual
+    int
+    version() const = 0;
 
     // Called on abnormal transport destruction. The idea's if the client disconnects unexpectedly,
     // i.e. not reaching the end of the dispatch graph, then some special handling might be needed.
@@ -72,20 +87,46 @@ public:
     virtual
     void
     discard(const std::error_code& ec) const;
-
-    // Observers
-
-    virtual
-    auto
-    root() const -> const graph_root_t& = 0;
-
-    auto
-    name() const -> std::string;
-
-    virtual
-    int
-    version() const = 0;
 };
+
+// Slot invocation with arguments provided as a MessagePack object
+
+class rpc_t:
+    public boost::static_visitor<boost::optional<dispatch_ptr_t>>
+{
+    const msgpack::object& unpacked;
+    const upstream_ptr_t&  upstream;
+
+public:
+    rpc_t(const msgpack::object& unpacked_, const upstream_ptr_t& upstream_):
+        unpacked(unpacked_),
+        upstream(upstream_)
+    { }
+
+    template<class Event>
+    result_type
+    operator()(const std::shared_ptr<basic_slot<Event>>& slot) const;
+};
+
+template<class Event>
+rpc_t::result_type
+rpc_t::operator()(const std::shared_ptr<basic_slot<Event>>& slot) const {
+    typedef basic_slot<Event> slot_type;
+
+    // Unpacked arguments storage.
+    typename slot_type::tuple_type args;
+
+    try {
+        // NOTE: Unpacks the object into a tuple using the argument typelist unlike using plain
+        // tuple type traits, in order to support parameter tags, like optional<T>.
+        type_traits<typename event_traits<Event>::argument_type>::unpack(unpacked, args);
+    } catch(const msgpack::type_error& e) {
+        throw std::system_error(error::invalid_argument, e.what());
+    }
+
+    // Call the slot with the upstream constrained with the event's upstream protocol type tag.
+    return result_type((*slot)(std::move(args), typename slot_type::upstream_type(upstream)));
+}
 
 } // namespace io
 
@@ -99,11 +140,12 @@ class dispatch:
 
     // Slot construction
 
+    typedef mpl::lambda
+        <std::shared_ptr<io::basic_slot<mpl::_1>>> slot_ptr;
+
     typedef typename mpl::transform<
         typename io::messages<Tag>::type,
-        typename mpl::lambda<
-            std::shared_ptr<io::basic_slot<mpl::_1>>
-        >::type
+        slot_ptr
     >::type slot_types;
 
     typedef std::map<
@@ -141,12 +183,15 @@ public:
 
     template<class Event>
     void
-    forget();
+    drop();
+
+    void
+    halt() { m_slots->clear(); }
 
 public:
     virtual
-    boost::optional<io::dispatch_ptr_t>
-    process(const io::decoder_t::message_type& message, const io::upstream_ptr_t& upstream) const;
+    auto
+    process(int id, const io::rpc_t& rpc) const -> boost::optional<io::dispatch_ptr_t>;
 
     virtual
     auto
@@ -163,8 +208,8 @@ public:
     // Generic API
 
     template<class Visitor>
-    typename Visitor::result_type
-    process(int id, const Visitor& visitor) const;
+    auto
+    process(int id, const Visitor& visitor) const -> typename Visitor::result_type;
 };
 
 template<class Tag>
@@ -189,45 +234,9 @@ struct select<streamed<R>, Event> {
     typedef io::deferred_slot<streamed, Event> type;
 };
 
-// Slot invocation with arguments provided as a MessagePack object
-
-struct calling_visitor_t:
-    public boost::static_visitor<boost::optional<io::dispatch_ptr_t>>
-{
-    calling_visitor_t(const msgpack::object& unpacked_, const io::upstream_ptr_t& upstream_):
-        unpacked(unpacked_),
-        upstream(upstream_)
-    { }
-
-    template<class Event>
-    result_type
-    operator()(const std::shared_ptr<io::basic_slot<Event>>& slot) const {
-        typedef io::basic_slot<Event> slot_type;
-
-        // Unpacked arguments storage.
-        typename slot_type::tuple_type args;
-
-        try {
-            // NOTE: Unpacks the object into a tuple using the argument typelist unlike using plain
-            // tuple type traits, in order to support parameter tags, like optional<T>.
-            io::type_traits<typename io::event_traits<Event>::argument_type>::unpack(unpacked, args);
-        } catch(const msgpack::type_error& e) {
-            throw std::system_error(error::invalid_argument, e.what());
-        }
-
-        // Call the slot with the upstream constrained with the event's upstream protocol type tag.
-        return result_type((*slot)(std::move(args), typename slot_type::upstream_type(upstream)));
-    }
-
-private:
-    const msgpack::object&    unpacked;
-    const io::upstream_ptr_t& upstream;
-};
-
 } // namespace aux
 
-template<class Tag>
-template<class Event, class F>
+template<class Tag> template<class Event, class F>
 dispatch<Tag>&
 dispatch<Tag>::on(const F& callable, typename boost::disable_if<is_slot<F, Event>>::type*) {
     typedef typename aux::select<
@@ -238,8 +247,7 @@ dispatch<Tag>::on(const F& callable, typename boost::disable_if<is_slot<F, Event
     return on<Event>(std::make_shared<slot_type>(callable));
 }
 
-template<class Tag>
-template<class Event>
+template<class Tag> template<class Event>
 dispatch<Tag>&
 dispatch<Tag>::on(const std::shared_ptr<io::basic_slot<Event>>& ptr) {
     typedef io::event_traits<Event> traits;
@@ -251,10 +259,9 @@ dispatch<Tag>::on(const std::shared_ptr<io::basic_slot<Event>>& ptr) {
     return *this;
 }
 
-template<class Tag>
-template<class Event>
+template<class Tag> template<class Event>
 void
-dispatch<Tag>::forget() {
+dispatch<Tag>::drop() {
     if(!m_slots->erase(io::event_traits<Event>::id)) {
         throw std::system_error(error::slot_not_found);
     }
@@ -262,12 +269,11 @@ dispatch<Tag>::forget() {
 
 template<class Tag>
 boost::optional<io::dispatch_ptr_t>
-dispatch<Tag>::process(const io::decoder_t::message_type& message, const io::upstream_ptr_t& upstream) const {
-    return process(message.type(), aux::calling_visitor_t(message.args(), upstream));
+dispatch<Tag>::process(int id, const io::rpc_t& rpc) const {
+    return process(id, rpc);
 }
 
-template<class Tag>
-template<class Visitor>
+template<class Tag> template<class Visitor>
 typename Visitor::result_type
 dispatch<Tag>::process(int id, const Visitor& visitor) const {
     typedef typename slot_map_t::mapped_type slot_ptr_type;

--- a/include/cocaine/rpc/dispatch.hpp
+++ b/include/cocaine/rpc/dispatch.hpp
@@ -140,8 +140,8 @@ class dispatch:
 
     // Slot construction
 
-    typedef mpl::lambda
-        <std::shared_ptr<io::basic_slot<mpl::_1>>> slot_ptr;
+    typedef mpl::lambda<
+        std::shared_ptr<io::basic_slot<mpl::_1>>> slot_ptr;
 
     typedef typename mpl::transform<
         typename io::messages<Tag>::type,

--- a/include/cocaine/rpc/dispatch.hpp
+++ b/include/cocaine/rpc/dispatch.hpp
@@ -77,8 +77,8 @@ public:
     root() const -> const graph_root_t& = 0;
 
     virtual
-    int
-    version() const = 0;
+    auto
+    version() const -> unsigned int = 0;
 
     // Called on abnormal transport destruction. The idea's if the client disconnects unexpectedly,
     // i.e. not reaching the end of the dispatch graph, then some special handling might be needed.
@@ -200,8 +200,8 @@ public:
     }
 
     virtual
-    int
-    version() const {
+    auto
+    version() const -> unsigned int {
         return io::protocol<Tag>::version::value;
     }
 

--- a/include/cocaine/rpc/dispatch.hpp
+++ b/include/cocaine/rpc/dispatch.hpp
@@ -270,7 +270,7 @@ dispatch<Tag>::drop() {
 template<class Tag>
 boost::optional<io::dispatch_ptr_t>
 dispatch<Tag>::process(int id, const io::rpc_t& rpc) const {
-    return process(id, rpc);
+    return process<io::rpc_t>(id, rpc);
 }
 
 template<class Tag> template<class Visitor>

--- a/include/cocaine/rpc/dispatch.hpp
+++ b/include/cocaine/rpc/dispatch.hpp
@@ -263,7 +263,7 @@ template<class Tag> template<class Event>
 void
 dispatch<Tag>::drop() {
     if(!m_slots->erase(io::event_traits<Event>::id)) {
-        throw std::system_error(error::slot_not_found);
+        throw std::system_error(error::slot_not_found, Event::alias());
     }
 }
 

--- a/include/cocaine/rpc/graph.hpp
+++ b/include/cocaine/rpc/graph.hpp
@@ -25,6 +25,8 @@
 #include <string>
 #include <tuple>
 
+#include <boost/functional/hash_fwd.hpp>
+
 #include <boost/optional.hpp>
 
 namespace cocaine { namespace io {
@@ -51,6 +53,15 @@ typedef std::map<
     int,
     std::tuple<std::string, boost::optional<graph_node_t>, boost::optional<graph_node_t>>
 > graph_root_t;
+
+// Support for computing hashes of protocols. Unless two different protocols have identical message
+// names in exactly the same spots in the graph, with exactly the same transitions, it'll be unique.
+
+template<class T>
+size_t
+hash_value(const boost::optional<T>& optional) {
+    return optional ? boost::hash<T>{}(optional.get()) : 0;
+}
 
 }} // namespace cocaine::io
 

--- a/include/cocaine/rpc/slot/deferred.hpp
+++ b/include/cocaine/rpc/slot/deferred.hpp
@@ -118,12 +118,6 @@ struct deferred {
         return *this;
     }
 
-    deferred&
-    abort(const std::error_code& ec, const std::string& reason) {
-        outbox->synchronize()->template append<typename protocol::error>(ec, reason);
-        return *this;
-    }
-
 #if defined(__clang__)
     deferred&
     abort(const std::error_code& ec) {
@@ -131,6 +125,12 @@ struct deferred {
         return *this;
     }
 #endif
+
+    deferred&
+    abort(const std::error_code& ec, const std::string& reason) {
+        outbox->synchronize()->template append<typename protocol::error>(ec, reason);
+        return *this;
+    }
 
     template<class UpstreamType>
     void
@@ -155,12 +155,6 @@ struct deferred<void> {
         outbox(new synchronized<queue_type>())
     { }
 
-    deferred&
-    abort(const std::error_code& ec, const std::string& reason) {
-        outbox->synchronize()->append<protocol::error>(ec, reason);
-        return *this;
-    }
-
 #if defined(__clang__)
     deferred&
     abort(const std::error_code& ec) {
@@ -168,6 +162,12 @@ struct deferred<void> {
         return *this;
     }
 #endif
+
+    deferred&
+    abort(const std::error_code& ec, const std::string& reason) {
+        outbox->synchronize()->append<protocol::error>(ec, reason);
+        return *this;
+    }
 
     deferred&
     close() {

--- a/include/cocaine/rpc/slot/streamed.hpp
+++ b/include/cocaine/rpc/slot/streamed.hpp
@@ -48,12 +48,6 @@ struct streamed {
         return *this;
     }
 
-    streamed&
-    abort(const std::error_code& ec, const std::string& reason) {
-        outbox->synchronize()->template append<typename protocol::error>(ec, reason);
-        return *this;
-    }
-
 #if defined(__clang__)
     streamed&
     abort(const std::error_code& ec) {
@@ -61,6 +55,12 @@ struct streamed {
         return *this;
     }
 #endif
+
+    streamed&
+    abort(const std::error_code& ec, const std::string& reason) {
+        outbox->synchronize()->template append<typename protocol::error>(ec, reason);
+        return *this;
+    }
 
     streamed&
     close() {

--- a/include/cocaine/trace/logger/blackhole.hpp
+++ b/include/cocaine/trace/logger/blackhole.hpp
@@ -74,7 +74,7 @@ public:
     template<typename Level>
     blackhole::record_t
     open_record(Level level, blackhole::attribute::set_t attributes = blackhole::attribute::set_t()) const {
-        // TODO: Do this under lock or drop assignment.
+        // TODO(@antmat): Do this under lock or drop assignment.
         AttributeFetcher fetcher;
         const auto& dynamic_attributes = fetcher();
         std::copy(this->attributes.begin(), this->attributes.end(), std::back_inserter(attributes));

--- a/include/cocaine/traits.hpp
+++ b/include/cocaine/traits.hpp
@@ -30,14 +30,14 @@ struct type_traits {
     template<class Stream>
     static inline
     void
-    pack(msgpack::packer<Stream>& packer, const T& source) {
-        packer << source;
+    pack(msgpack::packer<Stream>& target, const T& source) {
+        target << source;
     }
 
     static inline
     void
-    unpack(const msgpack::object& unpacked, T& target) {
-        unpacked >> target;
+    unpack(const msgpack::object& source, T& target) {
+        source >> target;
     }
 };
 

--- a/include/cocaine/traits/attributes.hpp
+++ b/include/cocaine/traits/attributes.hpp
@@ -33,8 +33,8 @@ struct type_traits<blackhole::attribute::value_t> {
     template<class Stream>
     static inline
     void
-    pack(msgpack::packer<Stream>& packer, const blackhole::attribute::value_t& source) {
-        blackhole::formatter::msgpack_visitor<Stream> visitor(&packer);
+    pack(msgpack::packer<Stream>& target, const blackhole::attribute::value_t& source) {
+        blackhole::formatter::msgpack_visitor<Stream> visitor(&target);
         boost::apply_visitor(visitor, source);
     }
 
@@ -73,8 +73,8 @@ struct type_traits<blackhole::attribute_t> {
     template<class Stream>
     static inline
     void
-    pack(msgpack::packer<Stream>& packer, const blackhole::attribute_t& source) {
-        type_traits<blackhole::attribute::value_t>::pack(packer, source.value);
+    pack(msgpack::packer<Stream>& target, const blackhole::attribute_t& source) {
+        type_traits<blackhole::attribute::value_t>::pack(target, source.value);
     }
 
     static inline

--- a/include/cocaine/traits/tuple.hpp
+++ b/include/cocaine/traits/tuple.hpp
@@ -130,15 +130,15 @@ struct sequence_type_error:
 struct sequence_size_error:
     public msgpack::type_error
 {
-    sequence_size_error(size_t size, size_t minimal):
-        message(cocaine::format("sequence size mismatch - got %d element(s), expected at least %d",
-            size, minimal
-        ))
+    sequence_size_error(size_t actual, size_t target): message(cocaine::format(
+        "sequence size mismatch - expected at least %d element(s), got %d",
+        target,
+        actual))
     { }
 
     virtual
    ~sequence_size_error() throw() {
-        // Empty.
+        // Empty. Required because of the mandatory throw() specification.
     }
 
     virtual
@@ -331,7 +331,7 @@ struct type_traits<std::tuple<Args...>> {
 template<typename T, typename U>
 struct type_traits<std::pair<T, U>>: public type_traits<std::tuple<T, U>> { };
 #else
-// Workaround for libraries, that violates the standard.
+// Workaround for libraries which violate the standard.
 template<typename T, typename U>
 struct type_traits<std::pair<T, U>> {
     typedef typename itemize<T, U>::type sequence_type;

--- a/include/cocaine/tuple.hpp
+++ b/include/cocaine/tuple.hpp
@@ -32,6 +32,8 @@
 
 namespace cocaine { namespace tuple {
 
+// Tuple element selection functor for standard algorithms
+
 template<size_t N>
 struct nth_element {
     template<class Tuple>
@@ -40,6 +42,8 @@ struct nth_element {
         return std::get<N>(tuple);
     }
 };
+
+// Folding MPL lists into a tuple's template argument pack
 
 namespace aux {
 
@@ -57,6 +61,20 @@ template<class End, class... Args>
 struct fold_impl<End, End, Args...> {
     typedef std::tuple<Args...> type;
 };
+
+} // namespace aux
+
+template<typename TypeList>
+struct fold {
+    typedef typename aux::fold_impl<
+        typename boost::mpl::begin<TypeList>::type,
+        typename boost::mpl::end  <TypeList>::type
+    >::type type;
+};
+
+// Function invocation with arguments provided as a tuple
+
+namespace aux {
 
 template<class IndexSequence>
 struct invoke_impl;
@@ -83,16 +101,6 @@ struct invoke_impl<index_sequence<Indices...>> {
 };
 
 } // namespace aux
-
-template<typename TypeList>
-struct fold {
-    typedef typename aux::fold_impl<
-        typename boost::mpl::begin<TypeList>::type,
-        typename boost::mpl::end  <TypeList>::type
-    >::type type;
-};
-
-// Function invocation with arguments provided as a tuple
 
 template<class F, class... Args>
 inline

--- a/include/cocaine/unique_id.hpp
+++ b/include/cocaine/unique_id.hpp
@@ -39,13 +39,11 @@ struct unique_id_t {
     bool
     operator==(const unique_id_t& other) const;
 
+    // Friends
+
     friend
     std::ostream&
     operator<<(std::ostream& stream, const unique_id_t& id);
-
-    static
-    bool
-    ensure(const std::string& uuid);
 
 public:
     // NOTE: Store 128-bit UUIDs as two 64-bit unsigned integers.

--- a/src/actor.cpp
+++ b/src/actor.cpp
@@ -102,8 +102,9 @@ actor_t::accept_action_t::finalize(const std::error_code& ec) {
         break;
     }
 
-    // TODO: Find out if it's always a good idea to continue accepting connections no matter what.
-    // For example, destroying a socket from outside this thread will trigger weird stuff on Linux.
+    // TODO(@kobolog): Find out if it's always a good idea to continue accepting connections no
+    // matter what. E.g., destroying a socket from outside this thread will trigger weird stuff
+    // on Linux.
     operator()();
 }
 

--- a/src/actor_unix.cpp
+++ b/src/actor_unix.cpp
@@ -48,7 +48,7 @@ private:
         auto ptr = std::make_unique<protocol_type::socket>(std::move(socket));
 
         switch(ec.value()) {
-        case 0:
+          case 0:
             COCAINE_LOG_DEBUG(parent->m_log, "accepted connection on fd %d", ptr->native_handle());
 
             try {
@@ -63,17 +63,18 @@ private:
 
             break;
 
-        case asio::error::operation_aborted:
+          case asio::error::operation_aborted:
             return;
 
-        default:
+          default:
             COCAINE_LOG_ERROR(parent->m_log, "unable to accept connection: [%d] %s", ec.value(),
                 ec.message());
             break;
         }
 
-        // TODO: Find out if it's always a good idea to continue accepting connections no matter what.
-        // For example, destroying a socket from outside this thread will trigger weird stuff on Linux.
+        // TODO(@kobolog): Find out if it's always a good idea to continue accepting connections no
+        // matter what. E.g., destroying a socket from outside this thread will trigger weird stuff
+        // on Linux.
         operator()();
     }
 };

--- a/src/cluster/multicast.cpp
+++ b/src/cluster/multicast.cpp
@@ -159,14 +159,14 @@ multicast_t::on_publish(const std::error_code& ec) {
         return;
     }
 
-    const auto actor = m_context.locate("locator");
+    const auto quoted = m_context.locate("locator");
 
-    if(!actor) {
+    if(!quoted) {
         COCAINE_LOG_ERROR(m_log, "unable to announce local endpoints: locator is not available");
         return;
     }
 
-    const auto endpoints = actor.get().endpoints();
+    const auto endpoints = quoted->location;
 
     if(!endpoints.empty()) {
         COCAINE_LOG_DEBUG(m_log, "announcing %d local endpoint(s)", endpoints.size())(

--- a/src/cluster/multicast.cpp
+++ b/src/cluster/multicast.cpp
@@ -45,13 +45,13 @@ namespace cocaine {
 namespace ph = std::placeholders;
 
 template<>
-struct dynamic_converter<address> {
-    typedef address result_type;
+struct dynamic_converter<ip::address> {
+    typedef ip::address result_type;
 
     static
     result_type
     convert(const dynamic_t& source) {
-        return address::from_string(source.as_string());
+        return ip::address::from_string(source.as_string());
     }
 };
 
@@ -66,7 +66,7 @@ struct dynamic_converter<multicast_cfg_t> {
 
         try {
             result.endpoint = udp::endpoint(
-                source.as_object().at("group").to<address>(),
+                source.as_object().at("group").to<ip::address>(),
                 source.as_object().at("port", 10053u).as_uint()
             );
         } catch(std::out_of_range& e) {
@@ -114,7 +114,7 @@ multicast_t::multicast_t(context_t& context, interface& locator, const std::stri
         auto interface = args.as_object().at("interface");
 
         if(m_cfg.endpoint.address().is_v4()) {
-            m_socket.set_option(multicast::outbound_interface(interface.to<address>().to_v4()));
+            m_socket.set_option(multicast::outbound_interface(interface.to<ip::address>().to_v4()));
         } else {
             m_socket.set_option(multicast::outbound_interface(interface.as_uint()));
         }

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -219,7 +219,7 @@ context_t::bootstrap() {
         terminate();
 
         // Force runtime to terminate.
-        throw cocaine::error_t("unable to start %d service(s): %s", boost::algorithm::join(errored, ", "));
+        throw cocaine::error_t(std::errc::operation_canceled, boost::algorithm::join(errored, ", "));
     } else {
         m_signals->invoke<io::context::prepared>();
     }

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -152,14 +152,13 @@ context_t::locate(const std::string& name) const {
     return m_services.apply(
         [&](const service_list_t& list) -> boost::optional<quote_t>
     {
-        auto it = std::find_if(list.begin(), list.end(), match{name});
+        const auto it = std::find_if(list.begin(), list.end(), match{name});
 
         if(it != list.end() && it->second->is_active()) {
-            return quote_t{
-                it->second->endpoints(),
-                it->second->prototype().version(),
-                it->second->prototype().root()
-            };
+            auto  bound = it->second->endpoints();
+            auto& proto = it->second->prototype();
+
+            return quote_t{std::move(bound), proto.version(), proto.root()};
         } else {
             return boost::none;
         }

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -105,7 +105,7 @@ context_t::insert(const std::string& name, std::unique_ptr<actor_t> service) {
     });
 
     // Fire off the signal to alert concerned subscribers about the service removal event.
-    m_signals.invoke<context::service::exposed>(actor.prototype().name(), std::forward_as_tuple(
+    m_signals->invoke<context::service::exposed>(actor.prototype().name(), std::forward_as_tuple(
         actor.endpoints(),
         actor.prototype().version(),
         actor.prototype().root()
@@ -138,7 +138,7 @@ context_t::remove(const std::string& name) {
     std::vector<asio::ip::tcp::endpoint> nothing;
 
     // Fire off the signal to alert concerned subscribers about the service termination event.
-    m_signals.invoke<context::service::removed>(service->prototype().name(), std::forward_as_tuple(
+    m_signals->invoke<context::service::removed>(service->prototype().name(), std::forward_as_tuple(
         nothing,
         service->prototype().version(),
         service->prototype().root()
@@ -220,7 +220,7 @@ context_t::bootstrap() {
         // Force runtime to terminate.
         throw cocaine::error_t("unable to start %d service(s): %s", boost::algorithm::join(errored, ", "));
     } else {
-        m_signals.invoke<io::context::prepared>();
+        m_signals->invoke<io::context::prepared>();
     }
 }
 
@@ -230,7 +230,7 @@ context_t::terminate() {
 
     // Fire off to alert concerned subscribers about the shutdown. This signal happens before all
     // the outstanding connections are closed, so services have a chance to send their last wishes.
-    m_signals.invoke<context::shutdown>();
+    m_signals->invoke<context::shutdown>();
 
     // Stop the service from accepting new clients or doing any processing. Pop them from the active
     // service list into this temporary storage, and then destroy them all at once. This is needed

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -149,16 +149,18 @@ context_t::remove(const std::string& name) {
 
 boost::optional<quote_t>
 context_t::locate(const std::string& name) const {
-    return m_services.apply(
-        [&](const service_list_t& list) -> boost::optional<quote_t>
-    {
-        const auto it = std::find_if(list.begin(), list.end(), match{name});
+    return m_services.apply([&](const service_list_t& list) -> boost::optional<quote_t> {
+        auto it = std::find_if(list.begin(), list.end(), match{name});
 
-        if(it != list.end() && it->second->is_active()) {
-            auto  bound = it->second->endpoints();
-            auto& proto = it->second->prototype();
+        if (it != list.end()) {
+            auto  endpoints = it->second->endpoints();
+            auto& prototype = it->second->prototype();
 
-            return quote_t{std::move(bound), proto.version(), proto.root()};
+            // TODO(@kobolog): Figure out if there should always be some endpoints for a
+            // service. Useless is_active() check was dropped, so adding this assert JIC.
+            BOOST_ASSERT(!endpoints.empty());
+
+            return quote_t{std::move(endpoints), prototype.version(), prototype.root()};
         } else {
             return boost::none;
         }

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -88,6 +88,7 @@ execution_unit_t::gc_action_t::finalize(const std::error_code& ec) {
         if(!it->second->memory_pressure()) {
             recycled++;
             it = parent->m_sessions.erase(it);
+
             continue;
         }
 

--- a/src/errors.cpp
+++ b/src/errors.cpp
@@ -34,25 +34,21 @@ using namespace cocaine::error;
 
 namespace {
 
-class unknown_category_t:
-    public std::error_category
-{
+class unknown_category_t: public std::error_category {
     virtual
     auto
     name() const throw() -> const char* {
-        return "unknown category";
+        return "unknown error category";
     }
 
     virtual
     auto
     message(int) const -> std::string {
-        return "unknown category error";
+        return "unknown error";
     }
 };
 
-class transport_category_t:
-    public std::error_category
-{
+class transport_category_t: public std::error_category {
     virtual
     auto
     name() const throw() -> const char* {
@@ -71,13 +67,11 @@ class transport_category_t:
         if(code == cocaine::error::transport_errors::parse_error)
             return "unable to parse the incoming data";
 
-        return "cocaine.rpc.transport error";
+        return cocaine::format("generic %s error", name());
     }
 };
 
-class dispatch_category_t:
-    public std::error_category
-{
+class dispatch_category_t: public std::error_category {
     virtual
     auto
     name() const throw() -> const char* {
@@ -102,13 +96,11 @@ class dispatch_category_t:
         if(code == cocaine::error::dispatch_errors::uncaught_error)
             return "uncaught invocation exception";
 
-        return "cocaine.rpc.dispatch error";
+        return cocaine::format("generic %s error", name());
     }
 };
 
-class repository_category_t:
-    public std::error_category
-{
+class repository_category_t: public std::error_category {
     virtual
     auto
     name() const throw() -> const char* {
@@ -131,13 +123,11 @@ class repository_category_t:
         if(code == cocaine::error::repository_errors::version_mismatch)
             return "component version requirements are not met";
 
-        return "cocaine.plugins error";
+        return cocaine::format("generic %s error", name());
     }
 };
 
-class security_category_t:
-    public std::error_category
-{
+class security_category_t: public std::error_category {
     virtual
     auto
     name() const throw() -> const char* {
@@ -150,7 +140,28 @@ class security_category_t:
         if(code == cocaine::error::security_errors::token_not_found)
             return "specified token is not available";
 
-        return "cocaine.security error";
+        return cocaine::format("generic %s error", name());
+    }
+};
+
+struct locator_category_t: public std::error_category {
+    virtual
+    auto
+    name() const throw() -> const char* {
+        return "cocaine.service.locator";
+    }
+
+    virtual
+    auto
+    message(int code) const -> std::string {
+        if(code == cocaine::error::locator_errors::service_not_available)
+            return "service is not available";
+        if(code == cocaine::error::locator_errors::routing_storage_error)
+            return "routing storage is unavailable";
+        if(code == cocaine::error::locator_errors::missing_version_error)
+            return "missing protocol version";
+
+        return cocaine::format("generic %s error", name());
     }
 };
 
@@ -184,6 +195,12 @@ security_category() -> const std::error_category& {
     return instance;
 }
 
+auto
+locator_category() -> const std::error_category& {
+    static locator_category_t instance;
+    return instance;
+}
+
 } // namespace
 
 namespace cocaine { namespace error {
@@ -207,6 +224,13 @@ auto
 make_error_code(security_errors code) -> std::error_code {
     return std::error_code(static_cast<int>(code), security_category());
 }
+
+auto
+make_error_code(locator_errors code) -> std::error_code {
+    return std::error_code(static_cast<int>(code), locator_category());
+}
+
+// Generic error message formatting
 
 std::string
 to_string(const std::system_error& e) {

--- a/src/gateway/adhoc.cpp
+++ b/src/gateway/adhoc.cpp
@@ -43,7 +43,7 @@ adhoc_t::resolve(const partition_t& name) const -> std::vector<asio::ip::tcp::en
     auto ptr = m_remotes.synchronize();
 
     if(!ptr->count(name)) {
-        throw std::system_error(error::service_not_available);
+        throw cocaine::error_t(error::service_not_available, std::get<0>(name));
     }
 
     std::tie(lb, ub) = ptr->equal_range(name);

--- a/src/gateway/adhoc.cpp
+++ b/src/gateway/adhoc.cpp
@@ -64,10 +64,7 @@ adhoc_t::consume(const std::string& uuid,
 {
     auto ptr = m_remotes.synchronize();
 
-    ptr->insert({
-        name,
-        remote_t{uuid, endpoints}
-    });
+    ptr->insert({name, remote_t{uuid, endpoints}});
 
     COCAINE_LOG_DEBUG(m_log, "registering destination with %d endpoints", endpoints.size())(
         "service", std::get<0>(name),

--- a/src/service/locator.cpp
+++ b/src/service/locator.cpp
@@ -52,11 +52,6 @@
 
 #include <boost/range/numeric.hpp>
 
-#include <boost/spirit/include/karma_char.hpp>
-#include <boost/spirit/include/karma_generate.hpp>
-#include <boost/spirit/include/karma_list.hpp>
-#include <boost/spirit/include/karma_string.hpp>
-
 using namespace cocaine;
 using namespace cocaine::io;
 using namespace cocaine::service;
@@ -78,30 +73,10 @@ class locator_t::connect_sink_t: public dispatch<event_traits<locator::connect>:
     std::set<api::gateway_t::partition_t> active;
 
 public:
-    connect_sink_t(locator_t *const parent_, const std::string& uuid_):
-        dispatch<event_traits<locator::connect>::upstream_type>(parent_->name() + ":client"),
-        parent(parent_),
-        uuid(uuid_)
-    {
-        typedef io::protocol<event_traits<locator::connect>::upstream_type>::scope protocol;
-
-        on<protocol::chunk>(std::bind(&connect_sink_t::on_announce, this, ph::_1, ph::_2));
-        on<protocol::choke>(std::bind(&connect_sink_t::on_shutdown, this));
-    }
+    connect_sink_t(locator_t *const parent_, const std::string& uuid_);
 
     virtual
-   ~connect_sink_t() {
-        auto lock = parent->m_clients.synchronize();
-
-        for(auto it = active.begin(); it != active.end(); ++it) tuple::invoke(
-            *it,
-            [&](const std::string& name, unsigned int version)
-        {
-            if(!parent->m_gateway->cleanup(uuid, *it)) parent->m_aggregate[name].erase(version);
-        });
-
-        cleanup();
-    }
+   ~connect_sink_t();
 
     virtual
     void
@@ -118,9 +93,35 @@ private:
     on_shutdown();
 };
 
+locator_t::connect_sink_t::connect_sink_t(locator_t *const parent_, const std::string& uuid_):
+    dispatch(parent_->name() + "/client"),
+    parent(parent_),
+    uuid(uuid_)
+{
+    typedef io::protocol<event_traits<locator::connect>::upstream_type>::scope protocol;
+
+    on<protocol::chunk>(std::bind(&connect_sink_t::on_announce, this, ph::_1, ph::_2));
+    on<protocol::choke>(std::bind(&connect_sink_t::on_shutdown, this));
+}
+
+locator_t::connect_sink_t::~connect_sink_t() {
+    auto lock = parent->m_clients.synchronize();
+
+    for(auto it = active.begin(); it != active.end(); ++it) tuple::invoke(
+        *it,
+        [&](const std::string& name, unsigned int version)
+    {
+        if(!parent->m_gateway->cleanup(uuid, *it)) parent->m_aggregate[name].erase(version);
+    });
+
+    cleanup();
+}
+
 void
 locator_t::connect_sink_t::discard(const std::error_code& ec) const {
-    if(ec.value() == 0) return;
+    if(ec.value() == 0) {
+        return;
+    }
 
     COCAINE_LOG_ERROR(parent->m_log, "remote client discarded: [%d] %s", ec.value(), ec.message())(
         "uuid", uuid
@@ -143,17 +144,14 @@ locator_t::connect_sink_t::cleanup() {
 }
 
 void
-locator_t::connect_sink_t::on_announce(const std::string& node,
-                                       std::map<std::string, results::resolve>&& update)
-{
+locator_t::connect_sink_t::on_announce(const std::string& node, std::map<std::string, results::resolve>&& update) {
     if(node != uuid) {
         COCAINE_LOG_ERROR(parent->m_log, "remote client id mismatch: '%s' vs. '%s'", uuid, node);
-
-        parent->drop_node(uuid);
+        return parent->drop_node(uuid);
+    } else if(update.empty()) {
+        COCAINE_LOG_DEBUG(parent->m_log, "remote client sent an empty announce");
         return;
     }
-
-    if(update.empty()) return;
 
     auto lock = parent->m_clients.synchronize();
 
@@ -179,16 +177,9 @@ locator_t::connect_sink_t::on_announce(const std::string& node,
         }
     });
 
-    std::ostringstream stream;
-    std::ostream_iterator<char> builder(stream);
+    const auto joined = boost::algorithm::join(update | boost::adaptors::map_keys, ", ");
 
-    boost::spirit::karma::generate(
-        builder,
-        boost::spirit::karma::string % ", ",
-        update | boost::adaptors::map_keys
-    );
-
-    COCAINE_LOG_INFO(parent->m_log, "remote client updated %d service(s): %s", update.size(), stream.str())(
+    COCAINE_LOG_INFO(parent->m_log, "received %d service announce(s): %s", update.size(), joined)(
         "uuid", uuid
     );
 
@@ -205,121 +196,141 @@ locator_t::connect_sink_t::on_shutdown() {
 }
 
 class locator_t::publish_slot_t: public basic_slot<locator::publish> {
-    struct publish_lock_t: public basic_slot<locator::publish>::dispatch_type {
+    locator_t *const parent;
+
+    class publish_sink_t: public basic_slot::dispatch_type {
         publish_slot_t *const parent;
         std::string     const handle;
 
-        publish_lock_t(publish_slot_t * const parent_, const std::string& handle_):
-            basic_slot<locator::publish>::dispatch_type("publish"),
+    public:
+        publish_sink_t(publish_slot_t *const parent_, const std::string& handle_):
+            basic_slot::dispatch_type("publish/discard"),
             parent(parent_),
             handle(handle_)
         {
-            on<locator::publish::discard>([this] { discard({}); });
+            on<locator::publish::discard>([this] { discard(std::error_code{}); });
         }
 
         virtual
         void
-        discard(const std::error_code& ec) const { parent->discard(ec, handle); }
+        discard(const std::error_code& ec) const { parent->on_discard(ec, handle); }
     };
 
-    typedef std::shared_ptr<const basic_slot::dispatch_type> result_type;
-
-    locator_t *const parent;
+    // Slot's transition type.
+    typedef boost::optional<std::shared_ptr<const basic_slot::dispatch_type>> result_type;
 
 public:
     publish_slot_t(locator_t *const parent_): parent(parent_) { }
 
     auto
-    operator()(tuple_type&& args, upstream_type&& upstream) -> boost::optional<result_type> {
-        const auto dispatch = cocaine::tuple::invoke(std::move(args),
-            [this](std::string&& handle, std::vector<tcp::endpoint>&& location,
-                   std::tuple<unsigned int, graph_root_t>&& metadata) -> result_type
-        {
-            scoped_attributes_t attributes(*parent->m_log, { attribute::make("service", handle) });
-
-            unsigned int versions;
-            graph_root_t protocol;
-
-            std::tie(versions, protocol) = metadata;
-
-            if(!protocol.empty() && versions == 0) {
-                throw std::system_error(error::missing_version_error);
-            }
-
-            COCAINE_LOG_INFO(parent->m_log, "publishing %s external service with %d endpoints",
-                protocol.empty() ? "non-native" : "native",
-                location.size());
-
-            parent->on_service(handle, results::resolve{location, versions, protocol}, modes::exposed);
-
-            return std::make_shared<publish_lock_t>(this, handle);
-        });
-
-        upstream.send<protocol<event_traits<locator::publish>::upstream_type>::scope::value>();
-
-        return boost::make_optional(dispatch);
-    }
+    operator()(tuple_type&& args, upstream_type&& upstream) -> result_type;
 
 private:
     void
-    discard(const std::error_code& ec, const std::string& handle) {
-        scoped_attributes_t attributes(*parent->m_log, { attribute::make("service", handle) });
-
-        COCAINE_LOG_INFO(parent->m_log, "external service disconnected, unpublishing: [%d] %s",
-            ec.value(), ec.message());
-
-        return parent->on_service(handle, results::resolve{}, modes::removed);
-    }
+    on_discard(const std::error_code& ec, const std::string& handle);
 };
 
+auto
+locator_t::publish_slot_t::operator()(tuple_type&& args, upstream_type&& upstream) -> result_type {
+    const auto dispatch = cocaine::tuple::invoke(std::move(args),
+        [this](std::string&& handle, std::vector<tcp::endpoint>&& location,
+               std::tuple<unsigned int, graph_root_t>&& metadata) -> result_type::value_type
+    {
+        scoped_attributes_t attributes(*parent->m_log, { attribute::make("service", handle) });
+
+        unsigned int versions;
+        graph_root_t protocol;
+
+        std::tie(versions, protocol) = metadata;
+
+        if(!protocol.empty() && versions == 0) {
+            throw std::system_error(error::missing_version_error);
+        }
+
+        COCAINE_LOG_INFO(parent->m_log, "publishing %s external service with %d endpoints",
+            protocol.empty() ? "non-native" : "native",
+            location.size());
+
+        parent->on_service(handle, results::resolve{location, versions, protocol}, modes::exposed);
+
+        return std::make_shared<publish_sink_t>(this, handle);
+    });
+
+    // TODO(@kobolog): Way too verbose, replace with deferred<void> in-place close() call.
+    upstream.send<protocol<event_traits<locator::publish>::upstream_type>::scope::value>();
+
+    return result_type(dispatch);
+}
+
+void
+locator_t::publish_slot_t::on_discard(const std::error_code& ec, const std::string& handle) {
+    scoped_attributes_t attributes(*parent->m_log, { attribute::make("service", handle) });
+
+    COCAINE_LOG_INFO(parent->m_log, "external service disconnected, unpublishing: [%d] %s",
+        ec.value(), ec.message());
+
+    return parent->on_service(handle, results::resolve{}, modes::removed);
+}
+
 class locator_t::routing_slot_t: public basic_slot<locator::routing> {
-    struct routing_lock_t: public basic_slot<locator::routing>::dispatch_type {
+    locator_t *const parent;
+
+    class routing_sink_t: public basic_slot::dispatch_type {
         routing_slot_t *const parent;
         std::string     const handle;
 
-        routing_lock_t(routing_slot_t *const parent_, const std::string& handle_):
-            basic_slot<locator::routing>::dispatch_type("routing"),
+    public:
+        routing_sink_t(routing_slot_t *const parent_, const std::string& handle_):
+            basic_slot::dispatch_type("routing/discard"),
             parent(parent_),
             handle(handle_)
         {
-            on<locator::routing::discard>([this] { discard({}); });
+            on<locator::routing::discard>([this] { discard(std::error_code{}); });
         }
 
         virtual
         void
-        discard(const std::error_code& ec) const { parent->discard(ec, handle); }
+        discard(const std::error_code& ec) const { parent->on_discard(ec, handle); }
     };
 
-    typedef std::shared_ptr<const basic_slot::dispatch_type> result_type;
-
-    locator_t *const parent;
+    // Slot's transition type.
+    typedef boost::optional<std::shared_ptr<const basic_slot::dispatch_type>> result_type;
 
 public:
     routing_slot_t(locator_t *const parent_): parent(parent_) { }
 
     auto
-    operator()(tuple_type&& args, upstream_type&& upstream) -> boost::optional<result_type> {
-        const auto ruid = std::get<0>(args);
-
-        auto rv = parent->on_routing(ruid, true);
-        auto dispatch = std::make_shared<routing_lock_t>(this, ruid);
-
-        // Try to flush the initial routing group information (if available). This can throw.
-        rv.attach(std::move(upstream));
-
-        return boost::make_optional(result_type(dispatch));
-    }
+    operator()(tuple_type&& args, upstream_type&& upstream) -> result_type;
 
 private:
     void
-    discard(const std::error_code& ec, const std::string& handle) {
-        COCAINE_LOG_DEBUG(parent->m_log, "detaching outgoing stream for router '%s': [%d] %s",
-            handle,
-            ec.value(), ec.message());
-
-        parent->m_routers->erase(handle);
-    }
+    on_discard(const std::error_code& ec, const std::string& handle);
 };
+
+auto
+locator_t::routing_slot_t::operator()(tuple_type&& args, upstream_type&& upstream) -> result_type {
+    const auto dispatch = tuple::invoke(std::move(args),
+        [&](std::string&& ruid) -> result_type::value_type
+    {
+        auto rv = parent->on_routing(ruid, true);
+
+        // Try to flush the initial routing group information (if available).
+        rv.attach(std::move(upstream));
+
+        return std::make_shared<routing_sink_t>(this, ruid);
+    });
+
+    return result_type(dispatch);
+}
+
+void
+locator_t::routing_slot_t::on_discard(const std::error_code& ec, const std::string& handle) {
+    COCAINE_LOG_DEBUG(parent->m_log, "detaching outgoing stream for router '%s': [%d] %s",
+        handle,
+        ec.value(), ec.message());
+
+    parent->m_routers->erase(handle);
+}
 
 // Locator
 
@@ -346,17 +357,6 @@ locator_t::locator_t(context_t& context, io_service& asio, const std::string& na
 
     on<locator::publish>(std::make_shared<publish_slot_t>(this));
     on<locator::routing>(std::make_shared<routing_slot_t>(this));
-
-    // Service restrictions
-
-    if(!m_cfg.restricted.empty()) {
-        std::ostringstream stream;
-        std::ostream_iterator<char> builder(stream);
-
-        boost::spirit::karma::generate(builder, boost::spirit::karma::string % ", ", m_cfg.restricted);
-
-        COCAINE_LOG_INFO(m_log, "restricting %d service(s): %s", m_cfg.restricted.size(), stream.str());
-    }
 
     // Context signals slot
 
@@ -419,59 +419,52 @@ locator_t::asio() {
 
 void
 locator_t::link_node(const std::string& uuid, const std::vector<tcp::endpoint>& endpoints) {
-    auto mapping = m_clients.synchronize();
-
-    if(!m_gateway || mapping->count(uuid) != 0) {
+    if(m_clients.apply([&](client_map_t& mapping) {
+        return !m_gateway || mapping[uuid] != nullptr;
+    })) {
         return;
-    }
+    };
 
-    auto  socket = std::make_shared<tcp::socket>(m_asio);
-    auto& uplink = ((*mapping)[uuid] = {endpoints, nullptr});
+    typedef std::pair<std::unique_ptr<tcp::socket>, std::vector<tcp::endpoint>> uplink_type;
 
-    asio::async_connect(*socket, uplink.endpoints.begin(), uplink.endpoints.end(),
+    const auto uplink = std::make_shared<uplink_type>(
+        std::make_unique<tcp::socket>(m_asio),
+        // This vector should be kept alive because of the retarded ASIO API.
+        endpoints
+    );
+
+    asio::async_connect(*uplink->first, uplink->second.begin(), uplink->second.end(),
         [=](const std::error_code& ec, std::vector<tcp::endpoint>::const_iterator endpoint)
     {
         scoped_attributes_t attributes(*m_log, { attribute::make("uuid", uuid) });
 
         auto session = m_clients.apply(
-            [&](client_map_t& mapping) -> std::shared_ptr<cocaine::session<asio::ip::tcp>>
+            [&](client_map_t& mapping) -> client_map_t::mapped_type
         {
+            auto ptr = std::move(uplink->first);
+
             if(mapping.count(uuid) == 0) {
-                COCAINE_LOG_ERROR(m_log, "remote disappeared while connecting");
-                return nullptr;
-            }
-
-            if(ec) {
-                COCAINE_LOG_ERROR(m_log, "unable to connect to remote: [%d] %s", ec.value(), ec.message());
+                COCAINE_LOG_ERROR(m_log, "remote has been lost during the connection attempt");
+            } else if(ec) {
+                COCAINE_LOG_ERROR(m_log, "unable to connect: [%d] %s", ec.value(), ec.message());
                 mapping.erase(uuid);
-
-                // TODO: Wrap link_node() in some sort of exponential back-off.
-                m_asio.post([=] { link_node(uuid, endpoints); });
-                return nullptr;
+            } else {
+                return (mapping.at(uuid) = m_context.engine().attach(std::move(ptr), nullptr));
             }
 
-            COCAINE_LOG_DEBUG(m_log, "connected to remote via %s", *endpoint);
-
-            // Uniquify the socket object.
-            auto ptr = std::make_unique<tcp::socket>(std::move(*socket));
-
-            return (mapping.at(uuid).ptr = m_context.engine().attach(std::move(ptr), nullptr));
+            return nullptr;
         });
 
-        // Something went wrong in the session creation code above, bail out.
-        if(!session) return;
-
-        auto upstream = session->fork(std::make_shared<connect_sink_t>(this, uuid));
-
-        try {
-            upstream->send<locator::connect>(m_cfg.uuid);
+        if(session != nullptr) try {
+            COCAINE_LOG_DEBUG(m_log, "establishing incoming locator stream via %s", *endpoint);
+            session->fork(std::make_shared<connect_sink_t>(this, uuid))->send<locator::connect>(m_cfg.uuid);
         } catch(const std::system_error& e) {
-            COCAINE_LOG_ERROR(m_log, "unable to set up remote stream: %s", error::to_string(e));
+            COCAINE_LOG_ERROR(m_log, "unable to setup remote client: %s", error::to_string(e));
             m_clients->erase(uuid);
         }
     });
 
-    COCAINE_LOG_INFO(m_log, "setting up remote client, trying %d route(s)", endpoints.size())(
+    COCAINE_LOG_INFO(m_log, "setting up remote client, trying %d endpoint(s)", endpoints.size())(
         "uuid", uuid
     );
 }
@@ -480,25 +473,26 @@ void
 locator_t::drop_node(const std::string& uuid) {
     m_remotes->erase(uuid);
 
-    std::shared_ptr<session<asio::ip::tcp>> session;
-
-    m_clients.apply([&](client_map_t& mapping) {
+    auto session = m_clients.apply(
+        [&](client_map_t& mapping) -> client_map_t::mapped_type
+    {
         auto it = mapping.find(uuid);
 
         if(!m_gateway || it == mapping.end()) {
-            return;
+            return nullptr;
         }
 
         COCAINE_LOG_INFO(m_log, "shutting down remote client")(
             "uuid", uuid
         );
 
-        session = it->second.ptr;
-        mapping.erase(it);
+        auto session = std::move(it->second); mapping.erase(it);
+
+        return session;
     });
 
-    if(session) {
-        session->detach(std::error_code());
+    if(session != nullptr) {
+        session->detach(std::error_code{});
     }
 }
 
@@ -519,55 +513,60 @@ locator_t::on_resolve(const std::string& name, const std::string& seed) const {
 
     scoped_attributes_t attributes(*m_log, { attribute::make("service", remapped) });
 
-    if(const auto provided = m_context.locate(remapped)) {
-        COCAINE_LOG_DEBUG(m_log, "providing service using local actor");
+    // TODO(@kobolog):
+    //   - Separate aggregate and client synchronization, like in RGs vs. Routers.
+    //   - Move local actor resolving back out of the critical section.
 
-        return results::resolve {
-            provided.get().endpoints(),
-            provided.get().prototype().version(),
-            provided.get().prototype().root()
-        };
-    }
+    return m_clients.apply([&](const client_map_t& /***/) -> results::resolve {
+        auto it = m_aggregate.end();
 
-    auto lock = m_clients.synchronize();
-    auto it   = m_aggregate.end();
+        if(const auto provided = m_context.locate(remapped)) {
+            COCAINE_LOG_DEBUG(m_log, "providing service using local actor");
 
-    if(m_gateway && (it = m_aggregate.find(remapped)) != m_aggregate.end()) {
-        const auto proto = *it->second.begin();
+            return results::resolve{
+                provided.get().endpoints(),
+                provided.get().prototype().version(),
+                provided.get().prototype().root()
+            };
+        } else if(m_gateway && (it = m_aggregate.find(remapped)) != m_aggregate.end()) {
+            const auto& protocol = *it->second.begin();
 
-        return results::resolve {
-            m_gateway->resolve(api::gateway_t::partition_t{remapped, proto.first}),
-            proto.first,
-            proto.second
-        };
-    } else {
-        throw std::system_error(error::service_not_available);
-    }
+            return results::resolve{
+                m_gateway->resolve(api::gateway_t::partition_t{remapped, protocol.first}),
+                protocol.first,
+                protocol.second
+            };
+        } else {
+            throw std::system_error(error::service_not_available);
+        }
+    });
 }
 
 auto
 locator_t::on_connect(const std::string& uuid) -> streamed<results::connect> {
-    streamed<results::connect> stream;
-
     scoped_attributes_t attributes(*m_log, { attribute::make("uuid", uuid) });
 
-    auto mapping = m_remotes.synchronize();
+    return m_remotes.apply([&](remote_map_t& mapping) -> streamed<results::connect> {
+        remote_map_t::iterator lb, ub;
 
-    if(!m_cluster) {
-        // No cluster means there are no streams.
-        return stream.close();
-    }
+        std::tie(lb, ub) = mapping.equal_range(uuid);
 
-    if(mapping->erase(uuid) == 0) {
-        COCAINE_LOG_INFO(m_log, "attaching outgoing stream for locator");
-    }
+        if(lb != ub) {
+            lb->second.close(); mapping.erase(lb);
+        } else {
+            COCAINE_LOG_INFO(m_log, "attaching outgoing stream for remote locator");
+        }
 
-    // Store the stream to synchronize future service updates with the remote node. Updates are
-    // sent out on context service signals, and propagate to all nodes in the cluster.
-    mapping->insert({uuid, stream});
+        // Create an unattached stream. Stream will be attached on function return.
+        streamed<results::connect> stream;
 
-    // NOTE: Even if there's nothing to return, still send out an empty update.
-    return stream.write(m_cfg.uuid, m_snapshots);
+        // Store the stream to synchronize future service updates with the remote node. Updates are
+        // sent out on context service signals, and propagate to all nodes in the cluster.
+        mapping.insert(ub, std::make_pair(uuid, stream));
+
+        // NOTE: Even if there's nothing to return, still send out an empty update.
+        return stream.write(m_cfg.uuid, m_snapshots);
+    });
 }
 
 void
@@ -600,10 +599,10 @@ locator_t::on_refresh(const std::vector<std::string>& groups) {
                 COCAINE_LOG_INFO(m_log, "updating routing group");
 
                 result.insert(std::make_pair(group, continuum_t(
-                    std::make_unique<logging::log_t>(*m_log, attribute::set_t()),
+                    std::make_unique<logging::log_t>(*m_log, attribute::set_t{}),
                     storage->get<continuum_t::stored_type>("groups", group))));
             } catch(const std::system_error& e) {
-                COCAINE_LOG_ERROR(m_log, "unable to pre-load routing group data for update: %s",
+                COCAINE_LOG_ERROR(m_log, "unable to preload routing group data for update: %s",
                     error::to_string(e));
                 throw std::system_error(error::routing_storage_error);
             }
@@ -621,13 +620,14 @@ locator_t::on_refresh(const std::vector<std::string>& groups) {
     for(auto it = ruids.begin(); it != ruids.end(); ++it) try {
         on_routing(*it);
     } catch(const std::system_error& e) {
-        COCAINE_LOG_WARNING(m_log, "unable to enqueue routing updates for router '%s': %s",
+        COCAINE_LOG_WARNING(m_log, "unable to enqueue routing update for router '%s': %s",
             *it,
             error::to_string(e));
+
         m_routers->erase(*it);
     }
 
-    COCAINE_LOG_DEBUG(m_log, "enqueued sending routing updates to %d router(s)", ruids.size());
+    COCAINE_LOG_DEBUG(m_log, "enqueued routing updates for %d router(s)", ruids.size());
 }
 
 results::cluster
@@ -635,10 +635,10 @@ locator_t::on_cluster() const {
     return boost::accumulate(*m_clients.synchronize(), results::cluster{},
         [](results::cluster result, const client_map_t::value_type& value) -> results::cluster
     {
-        const auto& session = value.second.ptr;
+        const auto& session = value.second;
 
         // NOTE: Some sessions might be nullptr because there is a connection attempt in progress.
-        result[value.first] = session ? session->remote_endpoint() : ip::tcp::endpoint();
+        result[value.first] = session ? session->remote_endpoint() : ip::tcp::endpoint{};
 
         return result;
     });
@@ -646,7 +646,7 @@ locator_t::on_cluster() const {
 
 auto
 locator_t::on_routing(const std::string& ruid, bool replace) -> streamed<results::routing> {
-    auto results = results::routing();
+    auto results = results::routing{};
     auto builder = std::inserter(results, results.end());
 
     boost::transform(*m_rgs.synchronize(), builder,
@@ -656,7 +656,13 @@ locator_t::on_routing(const std::string& ruid, bool replace) -> streamed<results
     });
 
     auto stream = m_routers.apply([&](router_map_t& mapping) -> streamed<results::routing> {
-        if(mapping.count(ruid) == 0 || (replace && mapping.erase(ruid))) {
+        router_map_t::iterator lb, ub;
+
+        std::tie(lb, ub) = mapping.equal_range(ruid);
+
+        if(replace && lb != ub) {
+            lb->second.close(); mapping.erase(lb);
+        } else {
             COCAINE_LOG_INFO(m_log, "attaching outgoing stream for router '%s'", ruid);
         }
 
@@ -669,38 +675,45 @@ locator_t::on_routing(const std::string& ruid, bool replace) -> streamed<results
 
 void
 locator_t::on_service(const std::string& name, const results::resolve& meta, modes mode) {
+    scoped_attributes_t attributes(*m_log, { attribute::make("service", name) });
+
     if(m_cfg.restricted.count(name)) {
+        COCAINE_LOG_DEBUG(m_log, "ignoring service update due to restrictions");
         return;
     }
 
-    scoped_attributes_t attributes(*m_log, { attribute::make("service", name) });
+    // TODO(@kobolog):
+    //   - Separate snapshotting and remote stream synchronization, like in RGs vs. Routers.
+    //   - Send updates out from outside the critical section.
+    //   - Batch updates into reasonable-sized announces and flush every few seconds.
 
-    auto mapping = m_remotes.synchronize();
+    m_remotes.apply([&](remote_map_t& mapping) {
+        if(mode == modes::exposed) {
+            if(m_snapshots.count(name) != 0) {
+                COCAINE_LOG_ERROR(m_log, "duplicate service detected");
+                return;
+            }
 
-    if(mode == modes::exposed) {
-        if(m_snapshots.count(name) != 0) {
-            COCAINE_LOG_ERROR(m_log, "duplicate service detected");
-            return;
+            m_snapshots[name] = meta;
+        } else {
+            m_snapshots.erase(name);
         }
 
-        m_snapshots[name] = meta;
-    } else {
-        m_snapshots.erase(name);
-    }
+        const auto update = results::connect{m_cfg.uuid, {{name, meta}}};
 
-    const auto response = results::connect{m_cfg.uuid, {{name, meta}}};
+        for(auto it = mapping.begin(); it != mapping.end(); /***/) try {
+            it->second.write(update);
+            it++;
+        } catch(const std::system_error& e) {
+            COCAINE_LOG_WARNING(m_log, "unable to enqueue service update for locator '%s': %s",
+                it->first,
+                error::to_string(e));
 
-    for(auto it = mapping->begin(); it != mapping->end(); /***/) try {
-        it->second.write(response);
-        it++;
-    } catch(const std::system_error& e) {
-        COCAINE_LOG_WARNING(m_log, "unable to enqueue service updates for locator '%s': %s",
-            it->first,
-            error::to_string(e));
-        it = mapping->erase(it);
-    }
+            it = mapping.erase(it);
+        }
 
-    COCAINE_LOG_DEBUG(m_log, "enqueued sending service updates to %d locators", mapping->size());
+        COCAINE_LOG_DEBUG(m_log, "enqueued service updates for %d locator(s)", mapping.size());
+    });
 }
 
 void
@@ -714,20 +727,21 @@ locator_t::on_context_shutdown() {
             COCAINE_LOG_DEBUG(m_log, "shutting down %d remote client(s)", mapping.size());
         }
 
-        mapping.clear();
+        boost::for_each(mapping | boost::adaptors::map_values, [](client_map_t::mapped_type& ptr) {
+            ptr->detach(std::error_code{});
+            ptr = nullptr;
+        });
     });
 
     m_remotes.apply([this](remote_map_t& mapping) {
-        m_cluster = nullptr;
-
         if(mapping.empty()) {
             return;
         } else {
-            COCAINE_LOG_DEBUG(m_log, "closing %d outgoing locator streams", mapping.size());
+            COCAINE_LOG_DEBUG(m_log, "closing %d outgoing locator stream(s)", mapping.size());
         }
 
         boost::for_each(mapping | boost::adaptors::map_values, [](streamed<results::connect>& s) {
-            try { s.close(); } catch(...) { /* None */ }
+            try { s.close(); } catch(...) { /***/ }
         });
     });
 
@@ -735,59 +749,13 @@ locator_t::on_context_shutdown() {
         if(mapping.empty()) {
             return;
         } else {
-            COCAINE_LOG_DEBUG(m_log, "closing %d outgoing routing streams", mapping.size());
+            COCAINE_LOG_DEBUG(m_log, "closing %d outgoing routing stream(s)", mapping.size());
         }
 
         boost::for_each(mapping | boost::adaptors::map_values, [](streamed<results::routing>& s) {
-            try { s.close(); } catch(...) { /* None */ }
+            try { s.close(); } catch(...) { /***/ }
         });
     });
 
-    m_signals = nullptr;
+    m_signals->halt();
 }
-
-namespace {
-
-// Locator errors
-
-struct locator_category_t:
-    public std::error_category
-{
-    virtual
-    auto
-    name() const throw() -> const char* {
-        return "cocaine.service.locator";
-    }
-
-    virtual
-    auto
-    message(int code) const -> std::string {
-        switch(code) {
-          case cocaine::error::locator_errors::service_not_available:
-            return "service is not available";
-          case cocaine::error::locator_errors::routing_storage_error:
-            return "routing storage is unavailable";
-          case cocaine::error::locator_errors::missing_version_error:
-            return "missing protocol version";
-        }
-
-        return "cocaine.service.locator error";
-    }
-};
-
-} // namespace
-
-namespace cocaine { namespace error {
-
-auto
-locator_category() -> const std::error_category& {
-    static locator_category_t instance;
-    return instance;
-}
-
-auto
-make_error_code(locator_errors code) -> std::error_code {
-    return std::error_code(static_cast<int>(code), locator_category());
-}
-
-}} // namespace cocaine::error

--- a/src/service/locator.cpp
+++ b/src/service/locator.cpp
@@ -689,6 +689,8 @@ locator_t::on_service(const std::string& name, const results::resolve& meta, mod
     //   - Batch updates into reasonable-sized announces and flush every few seconds.
 
     m_remotes.apply([&](remote_map_t& mapping) {
+        const auto update = results::connect{m_cfg.uuid, {{name, meta}}};
+
         if(mode == modes::exposed) {
             if(m_snapshots.count(name) != 0) {
                 COCAINE_LOG_ERROR(m_log, "duplicate service detected");
@@ -699,8 +701,6 @@ locator_t::on_service(const std::string& name, const results::resolve& meta, mod
         } else {
             m_snapshots.erase(name);
         }
-
-        const auto update = results::connect{m_cfg.uuid, {{name, meta}}};
 
         for(auto it = mapping.begin(); it != mapping.end(); /***/) try {
             it->second.write(update);

--- a/src/service/locator.cpp
+++ b/src/service/locator.cpp
@@ -542,7 +542,7 @@ locator_t::on_resolve(const std::string& name, const std::string& seed) const {
     } else if(remote) {
         return results::resolve{remote->location, remote->version, remote->protocol};
     } else {
-        throw std::system_error(error::service_not_available);
+        throw std::system_error(error::service_not_available, remapped);
     }
 }
 

--- a/src/service/locator.cpp
+++ b/src/service/locator.cpp
@@ -525,18 +525,16 @@ locator_t::on_resolve(const std::string& name, const std::string& seed) const {
             return boost::none;
         }
 
-        unsigned int version;
-        graph_root_t protocol;
+        auto protocol = graph_root_t{};
+        auto version  = 0u;
 
         // Aggregate is (version, protocol) tuples sorted by version in descending order, so
         // the most recent protocol version is chosen here and resolved against the Gateway.
         std::tie(version, protocol) = *it->second.begin();
 
-        return quote_t{
-            m_gateway->resolve(api::gateway_t::partition_t{remapped, version}),
-            version,
-            std::move(protocol)
-        };
+        auto location = m_gateway->resolve(api::gateway_t::partition_t{remapped, version});
+
+        return quote_t{std::move(location), version, std::move(protocol)};
     });
 
     if(const auto quoted = m_context.locate(remapped)) {

--- a/src/service/locator.cpp
+++ b/src/service/locator.cpp
@@ -628,6 +628,7 @@ locator_t::on_refresh(const std::vector<std::string>& groups) {
             *it,
             error::to_string(e));
 
+        // No close() required before stream destruction since it was already disconnected.
         m_routers->erase(*it);
     }
 
@@ -713,6 +714,7 @@ locator_t::on_service(const std::string& name, const results::resolve& meta, mod
                 it->first,
                 error::to_string(e));
 
+            // No close() required before stream destruction since it was already disconnected.
             it = mapping.erase(it);
         }
 
@@ -733,7 +735,6 @@ locator_t::on_context_shutdown() {
 
         boost::for_each(mapping | boost::adaptors::map_values, [](client_map_t::mapped_type& ptr) {
             ptr->detach(std::error_code{});
-            ptr = nullptr;
         });
     });
 
@@ -761,5 +762,7 @@ locator_t::on_context_shutdown() {
         });
     });
 
+    // It will remove all slots from the dispatch. If there are pending signals already waiting in
+    // the event loop's queue, they won't be triggered since no slots will be bound at that point.
     m_signals->halt();
 }

--- a/src/service/logging.cpp
+++ b/src/service/logging.cpp
@@ -71,7 +71,9 @@ logging_t::on_emit(logging::priorities level, std::string source, std::string me
 {
     auto record = wrapper->open_record(level, std::move(attributes));
 
-    if(!record) return;
+    if(!record) {
+        return;
+    }
 
     record.insert(cocaine::logging::keyword::source() = std::move(source));
     record.message(std::move(message));

--- a/src/session.cpp
+++ b/src/session.cpp
@@ -226,7 +226,7 @@ session_t::handle(const decoder_t::message_type& message) {
     });
 
     if(!channel->dispatch) {
-        throw std::system_error(error::unbound_dispatch);
+        throw std::system_error(error::unbound_dispatch, std::to_string(channel_id));
     }
 
     trace_t::restore_scope_t trace_scope(incoming_trace);

--- a/src/session.cpp
+++ b/src/session.cpp
@@ -86,7 +86,7 @@ session_t::pull_action_t::finalize(const std::error_code& ec) {
         try {
             // NOTE: In case the underlying slot has miserably failed to handle its exceptions, the
             // client will be disconnected to prevent any further damage to the service and himself.
-            session->handle(message); message.clear();
+            session->handle(message);
         } catch(const std::system_error& e) {
             COCAINE_LOG_ERROR(session->log, "uncaught invocation exception: %s", error::to_string(e));
             return session->detach(e.code());
@@ -94,6 +94,9 @@ session_t::pull_action_t::finalize(const std::error_code& ec) {
             COCAINE_LOG_ERROR(session->log, "uncaught invocation exception: %s", e.what());
             return session->detach(error::uncaught_error);
         }
+
+        // Removes the metadata from the previously received message since HPACK doesn't do cleanup.
+        message.clear();
 
         // Cycle the transport back into the message pump.
         operator()(std::move(ptr));
@@ -169,7 +172,11 @@ public:
 
 // Session
 
-session_t::session_t(std::unique_ptr<logging::log_t> log_, std::unique_ptr<transport_type> transport_, const dispatch_ptr_t& prototype_):
+session_t::session_t(
+    std::unique_ptr<logging::log_t> log_,
+    std::unique_ptr<transport_type> transport_,
+    const dispatch_ptr_t& prototype_
+):
     log(std::move(log_)),
     transport(std::shared_ptr<transport_type>(std::move(transport_))),
     prototype(prototype_),
@@ -199,26 +206,28 @@ session_t::handle(const decoder_t::message_type& message) {
             std::tie(lb, std::ignore) = mapping.insert({channel_id, std::make_shared<channel_t>(
                 prototype,
                 // Do not store trace if we handling server side.
-                std::make_shared<basic_upstream_t>(shared_from_this(), channel_id, boost::none)
+                std::make_shared<basic_upstream_t>(shared_from_this(), channel_id)
             )});
 
             max_channel_id = channel_id;
         }
 
-        if(lb->second->upstream->client_trace) {
-            incoming_trace = lb->second->upstream->client_trace;
-        } else {
+        if(!lb->second->upstream->trace) {
             auto trace_header = message.meta<hpack::headers::trace_id<>>();
             auto span_header = message.meta<hpack::headers::span_id<>>();
             auto parent_header = message.meta<hpack::headers::parent_id<>>();
+
             if(trace_header && span_header && parent_header) {
                 incoming_trace = trace_t(
                     trace_header->get_value().convert<uint64_t>(),
                     span_header->get_value().convert<uint64_t>(),
                     parent_header->get_value().convert<uint64_t>(),
+                    // TODO(@antmat): This can throw.
                     std::get<0>(lb->second->dispatch->root().at(message.type()))
                 );
             }
+        } else {
+            incoming_trace = lb->second->upstream->trace;
         }
 
         // NOTE: The virtual channel pointer is copied here to avoid data races.
@@ -286,17 +295,23 @@ upstream_ptr_t
 session_t::fork(const dispatch_ptr_t& dispatch) {
     return channels.apply([&](channel_map_t& mapping) -> upstream_ptr_t {
         const auto channel_id = ++max_channel_id;
-        auto trace = trace_t::current();
-        trace.push(dispatch->name());
-        const auto downstream = std::make_shared<basic_upstream_t>(shared_from_this(), channel_id, trace);
+        const auto downstream = std::make_shared<basic_upstream_t>(shared_from_this(), channel_id);
+
+        // TRACE: Either current trace if this was forked from an incoming request, or a new one.
+        downstream->trace = trace_t::current();
 
         COCAINE_LOG_DEBUG(log, "forking new channel %d, dispatch: '%s'", channel_id,
             dispatch ? dispatch->name() : "<none>");
 
         if(dispatch) {
+            downstream->trace->push(dispatch->name());
+
             // NOTE: For mute slots, creating a new channel will essentially leak memory, since no
             // response will ever be sent back, therefore the channel will never be revoked at all.
             mapping.insert({channel_id, std::make_shared<channel_t>(dispatch, downstream)});
+        } else {
+            // It is not clear whether it makes much sense to have a trace with "<none>" in RPC ID.
+            downstream->trace->push("<none>");
         }
 
         return downstream;
@@ -423,10 +438,14 @@ session_t::remote_endpoint() const {
 namespace cocaine {
 
 template<class Protocol>
-session<Protocol>::session(std::unique_ptr<logging::log_t> log, std::unique_ptr<transport_type> transport, const dispatch_ptr_t& prototype):
-    session_t(std::move(log),
-              std::make_unique<io::transport<generic::stream_protocol>>(std::move(*transport)),
-              std::move(prototype))
+session<Protocol>::session(
+    std::unique_ptr<logging::log_t> log,
+    std::unique_ptr<transport_type> transport,
+    const dispatch_ptr_t& prototype):
+session_t(
+    std::move(log),
+    std::make_unique<io::transport<generic::stream_protocol>>(std::move(*transport)),
+    prototype)
 { }
 
 template<>

--- a/src/session.cpp
+++ b/src/session.cpp
@@ -86,8 +86,7 @@ session_t::pull_action_t::finalize(const std::error_code& ec) {
         try {
             // NOTE: In case the underlying slot has miserably failed to handle its exceptions, the
             // client will be disconnected to prevent any further damage to the service and himself.
-            session->handle(message);
-            message.clear();
+            session->handle(message); message.clear();
         } catch(const std::system_error& e) {
             COCAINE_LOG_ERROR(session->log, "uncaught invocation exception: %s", error::to_string(e));
             return session->detach(e.code());

--- a/src/unique_id.cpp
+++ b/src/unique_id.cpp
@@ -58,12 +58,6 @@ unique_id_t::operator==(const unique_id_t& other) const {
            uuid[1] == other.uuid[1];
 }
 
-bool
-unique_id_t::ensure(const std::string& string) {
-    uuid_t uuid;
-    return uuid_parse(string.c_str(), uuid) == 0;
-}
-
 namespace cocaine {
 
 std::ostream&


### PR DESCRIPTION
A lot of tiny annoying crap:
  – Fixed a possible dangling reference in `context_t::locate()` (and broke Elliptics plugin – TBD).
  – Made `signal<T>` more predictable in when it triggers signals.
  – Fixed Locator's streams not being closed when a client with the same UUID asks for a new stream.
  – Dropped `boost::karma` for comma-sperated string concatenation in favor of `boost::join()`.
  – Moved almost all synchronized blocks to `locked_ptr<T>::apply()` calls for better traces.
  – Added more verbosity in log & error messages.
  – Flattened and simplified code all around the place.
  – Cleaned up Zipkin code a little bit.

NOTE: Commit squashing & rebasing TBD.